### PR TITLE
feat: Add Dependabot configuration for automated dependency updates (#51)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Backend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  # Rust/Cargo dependencies
+  - package-ecosystem: "cargo"
+    directory: "/contracts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "contracts"


### PR DESCRIPTION
### Summary
Configures GitHub Dependabot to automatically monitor and update dependencies across the project.

### Changes
- Added `.github/dependabot.yml` configuration file
- Enabled weekly dependency checks for:
  - Backend npm packages (`/backend`)
  - Frontend npm packages (`/frontend`)
  - Rust/Cargo packages (`/contracts`)

### Configuration Details
- **Schedule**: Weekly checks for all ecosystems
- **PR Limit**: Maximum 5 open PRs per ecosystem
- **Labels**: Automatically tagged with `dependencies` and component-specific labels (`backend`, `frontend`, `contracts`)

### Benefits
- Automated security updates for vulnerable dependencies
- Keeps dependencies up-to-date with minimal manual effort
- Clear labeling for easy PR triage and review
- Prevents dependency drift across the monorepo

### Testing
Once merged, Dependabot will begin scanning on its weekly schedule and open PRs for any outdated dependencies.

closes #51