### PR TITLE
 fix(auth): clear wallet_connector_id on 401 and centralise wallet storage keys

### DIFF
--- a/frontend/src/app/contexts/WalletContext.tsx
+++ b/frontend/src/app/contexts/WalletContext.tsx
@@ -21,6 +21,27 @@ import {
   type WalletConnector,
 } from "@/app/lib/wallet/freighterConnector";
 
+// ── Centralised storage keys ──────────────────────────────────────────────────
+// Single source of truth for all wallet localStorage keys.
+// Imported by apiClient.ts so the two can never drift apart.
+export const WALLET_STORAGE_KEYS = {
+  WALLET_CONNECTED:    "wallet_connected",
+  WALLET_PUBLIC_KEY:   "wallet_public_key",
+  WALLET_CONNECTOR_ID: "wallet_connector_id",
+} as const;
+
+/**
+ * Removes every wallet key from localStorage in one call.
+ * Exported so apiClient can delegate cleanup here instead of
+ * maintaining its own (incomplete) list of keys.
+ */
+export function clearWalletStorage(): void {
+  Object.values(WALLET_STORAGE_KEYS).forEach((key) =>
+    localStorage.removeItem(key)
+  );
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 interface WalletState {
   isConnected: boolean;
   publicKey: string | null;
@@ -71,11 +92,13 @@ export function WalletProvider({ children }: WalletProviderProps) {
         connectorId: freighterConnector.id,
       });
 
-      localStorage.setItem("wallet_connected", "true");
-      localStorage.setItem("wallet_public_key", publicKey);
-      localStorage.setItem("wallet_connector_id", freighterConnector.id);
+      // Use constants — never hardcode key strings
+      localStorage.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED,    "true");
+      localStorage.setItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY,   publicKey);
+      localStorage.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID, freighterConnector.id);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Failed to connect wallet";
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to connect wallet";
       setState({
         isConnected: false,
         publicKey: null,
@@ -91,8 +114,8 @@ export function WalletProvider({ children }: WalletProviderProps) {
    */
   const disconnect = useCallback(async () => {
     try {
-      // Freighter doesn't have a disconnect method, just clear local state
-      // User can disconnect from the extension itself
+      // Freighter doesn't have a disconnect method, just clear local state.
+      // User can disconnect from the extension itself.
     } catch (err) {
       console.error("Error disconnecting wallet:", err);
     } finally {
@@ -103,10 +126,9 @@ export function WalletProvider({ children }: WalletProviderProps) {
         error: null,
         connectorId: null,
       });
-
-      localStorage.removeItem("wallet_connected");
-      localStorage.removeItem("wallet_public_key");
-      localStorage.removeItem("wallet_connector_id");
+      // Centralised helper — clears wallet_connected, wallet_public_key,
+      // AND wallet_connector_id in one place
+      clearWalletStorage();
     }
   }, []);
 
@@ -115,8 +137,8 @@ export function WalletProvider({ children }: WalletProviderProps) {
   }, []);
 
   /**
-   * Listen for wallet disconnection events
-   * Stellar wallets emit events when user disconnects from extension
+   * Listen for wallet disconnection events.
+   * Stellar wallets emit events when user disconnects from extension.
    */
   useEffect(() => {
     const handleWalletDisconnect = () => {
@@ -127,14 +149,11 @@ export function WalletProvider({ children }: WalletProviderProps) {
         error: "Wallet disconnected",
         connectorId: null,
       });
-      localStorage.removeItem("wallet_connected");
-      localStorage.removeItem("wallet_public_key");
-      localStorage.removeItem("wallet_connector_id");
+      // Centralised helper — all three keys cleared
+      clearWalletStorage();
     };
 
-    // Listen for wallet events
     window.addEventListener("wallet_disconnected", handleWalletDisconnect);
-
     return () => {
       window.removeEventListener("wallet_disconnected", handleWalletDisconnect);
     };
@@ -144,22 +163,17 @@ export function WalletProvider({ children }: WalletProviderProps) {
    * Restore wallet connection on mount if previously connected
    */
   useEffect(() => {
-    const wasConnected = localStorage.getItem("wallet_connected") === "true";
-    const savedPublicKey = localStorage.getItem("wallet_public_key");
-    const connectorId = localStorage.getItem("wallet_connector_id");
+    const wasConnected =
+      localStorage.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED) === "true";
+    const savedPublicKey =
+      localStorage.getItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY);
+    const connectorId =
+      localStorage.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID);
 
-    const clearPersistedWallet = () => {
-      localStorage.removeItem("wallet_connected");
-      localStorage.removeItem("wallet_public_key");
-      localStorage.removeItem("wallet_connector_id");
-    };
-
-    if (!wasConnected || !savedPublicKey) {
-      return;
-    }
+    if (!wasConnected || !savedPublicKey) return;
 
     if (connectorId && connectorId !== freighterConnector.id) {
-      clearPersistedWallet();
+      clearWalletStorage();
       return;
     }
 
@@ -167,16 +181,14 @@ export function WalletProvider({ children }: WalletProviderProps) {
       .isConnected()
       .then((isConnected) => {
         if (!isConnected) {
-          clearPersistedWallet();
+          clearWalletStorage();
           return;
         }
-
         return freighterConnector.getPublicKey().then((publicKey) => {
           if (publicKey !== savedPublicKey) {
-            clearPersistedWallet();
+            clearWalletStorage();
             return;
           }
-
           setState({
             isConnected: true,
             publicKey: savedPublicKey,
@@ -186,7 +198,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
           });
         });
       })
-      .catch(clearPersistedWallet);
+      .catch(clearWalletStorage);
   }, []);
 
   const value: WalletContextValue = {
@@ -202,16 +214,10 @@ export function WalletProvider({ children }: WalletProviderProps) {
   );
 }
 
-/**
- * Hook to access wallet context
- * Throws error if used outside WalletProvider
- */
 export function useWallet(): WalletContextValue {
   const context = useContext(WalletContext);
-  
   if (context === undefined) {
     throw new Error("useWallet must be used within a WalletProvider");
   }
-  
   return context;
 }

--- a/frontend/src/app/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/app/contexts/__tests__/AuthContext.test.tsx
@@ -6,36 +6,26 @@
 
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { AuthProvider, useAuth } from "../AuthContext";
-import { WalletProvider } from "../WalletContext";
+import { WalletProvider, WALLET_STORAGE_KEYS } from "../WalletContext";
 
 // Mock next/navigation
 const mockPush = jest.fn();
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 // Mock localStorage
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
   return {
-    getItem: (key: string) => store[key] || null,
-    setItem: (key: string, value: string) => {
-      store[key] = value;
-    },
-    removeItem: (key: string) => {
-      delete store[key];
-    },
-    clear: () => {
-      store = {};
-    },
+    getItem:    (key: string) => store[key] ?? null,
+    setItem:    (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear:      () => { store = {}; },
   };
 })();
 
-Object.defineProperty(window, "localStorage", {
-  value: localStorageMock,
-});
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
 
 // Mock fetch
 global.fetch = jest.fn();
@@ -53,9 +43,10 @@ describe("AuthContext", () => {
     mockPush.mockClear();
   });
 
+  // ── Existing tests ────────────────────────────────────────────────────────
+
   it("should initialize with unauthenticated state", () => {
     const { result } = renderHook(() => useAuth(), { wrapper });
-
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.token).toBeNull();
   });
@@ -63,9 +54,7 @@ describe("AuthContext", () => {
   it("should login and store token", () => {
     const { result } = renderHook(() => useAuth(), { wrapper });
 
-    act(() => {
-      result.current.login("test-token", 3600);
-    });
+    act(() => { result.current.login("test-token", 3600); });
 
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.token).toBe("test-token");
@@ -75,17 +64,10 @@ describe("AuthContext", () => {
   it("should logout and clear state", async () => {
     const { result } = renderHook(() => useAuth(), { wrapper });
 
-    // Login first
-    act(() => {
-      result.current.login("test-token", 3600);
-    });
-
+    act(() => { result.current.login("test-token", 3600); });
     expect(result.current.isAuthenticated).toBe(true);
 
-    // Logout
-    await act(async () => {
-      await result.current.logout();
-    });
+    await act(async () => { await result.current.logout(); });
 
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.token).toBeNull();
@@ -95,29 +77,20 @@ describe("AuthContext", () => {
 
   it("should detect expired token", () => {
     jest.useFakeTimers();
-    
     const { result } = renderHook(() => useAuth(), { wrapper });
 
-    // Login with token that expires in 1 second
-    act(() => {
-      result.current.login("test-token", 1);
-    });
-
+    act(() => { result.current.login("test-token", 1); });
     expect(result.current.isTokenExpired()).toBe(false);
 
-    // Wait for expiration
-    act(() => {
-      jest.advanceTimersByTime(2000);
-    });
-
+    act(() => { jest.advanceTimersByTime(2000); });
     expect(result.current.isTokenExpired()).toBe(true);
-    
+
     jest.useRealTimers();
   });
 
   it("should restore auth state from localStorage", () => {
     const expiresAt = Date.now() + 3600000;
-    localStorageMock.setItem("auth_token", "stored-token");
+    localStorageMock.setItem("auth_token",      "stored-token");
     localStorageMock.setItem("auth_expires_at", expiresAt.toString());
 
     const { result } = renderHook(() => useAuth(), { wrapper });
@@ -127,8 +100,8 @@ describe("AuthContext", () => {
   });
 
   it("should not restore expired token from localStorage", () => {
-    const expiresAt = Date.now() - 1000; // Expired
-    localStorageMock.setItem("auth_token", "expired-token");
+    const expiresAt = Date.now() - 1000;
+    localStorageMock.setItem("auth_token",      "expired-token");
     localStorageMock.setItem("auth_expires_at", expiresAt.toString());
 
     const { result } = renderHook(() => useAuth(), { wrapper });
@@ -145,58 +118,56 @@ describe("AuthContext", () => {
 
     const { result } = renderHook(() => useAuth(), { wrapper });
 
-    act(() => {
-      result.current.login("old-token", 3600);
-    });
+    act(() => { result.current.login("old-token", 3600); });
 
-    let refreshResult: boolean = false;
-    await act(async () => {
-      refreshResult = await result.current.refreshToken();
-    });
+    let refreshResult = false;
+    await act(async () => { refreshResult = await result.current.refreshToken(); });
 
     expect(refreshResult).toBe(true);
     expect(result.current.token).toBe("new-token");
   });
 
   it("should logout on failed token refresh", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: false,
-      status: 401,
-    });
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 401 });
 
     const { result } = renderHook(() => useAuth(), { wrapper });
 
-    act(() => {
-      result.current.login("old-token", 3600);
-    });
+    act(() => { result.current.login("old-token", 3600); });
 
-    let refreshResult: boolean = true;
-    await act(async () => {
-      refreshResult = await result.current.refreshToken();
-    });
+    let refreshResult = true;
+    await act(async () => { refreshResult = await result.current.refreshToken(); });
 
     expect(refreshResult).toBe(false);
     expect(result.current.isAuthenticated).toBe(false);
     expect(mockPush).toHaveBeenCalledWith("/");
   });
 
-  it("should handle session expiry event", async () => {
+  it("should handle session expiry event and clear ALL wallet keys including wallet_connector_id", async () => {
     const { result } = renderHook(() => useAuth(), { wrapper });
 
-    act(() => {
-      result.current.login("test-token", 3600);
-    });
+    act(() => { result.current.login("test-token", 3600); });
+
+    // Seed all wallet keys — simulates state after a normal wallet connect
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED,    "true");
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY,   "GFAKE123");
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID, "freighter");
 
     expect(result.current.isAuthenticated).toBe(true);
 
-    // Dispatch session expired event
+    // apiClient dispatches this on 401
     await act(async () => {
       window.dispatchEvent(new CustomEvent("auth_session_expired"));
     });
 
     await waitFor(() => {
+      // Auth cleared
       expect(result.current.isAuthenticated).toBe(false);
       expect(mockPush).toHaveBeenCalledWith("/");
+
+      // All wallet keys cleared — wallet_connector_id must not survive
+      expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED)).toBeNull();
+      expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY)).toBeNull();
+      expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID)).toBeNull();
     });
   });
 });

--- a/frontend/src/app/contexts/__tests__/WalletContext.test.tsx
+++ b/frontend/src/app/contexts/__tests__/WalletContext.test.tsx
@@ -5,51 +5,49 @@
  */
 
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { WalletProvider, useWallet } from "../WalletContext";
+import {
+  WalletProvider,
+  useWallet,
+  WALLET_STORAGE_KEYS,
+  clearWalletStorage,
+} from "../WalletContext";
 
 // Mock localStorage
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
   return {
-    getItem: (key: string) => store[key] || null,
-    setItem: (key: string, value: string) => {
-      store[key] = value;
-    },
-    removeItem: (key: string) => {
-      delete store[key];
-    },
-    clear: () => {
-      store = {};
-    },
+    getItem:    (key: string) => store[key] ?? null,
+    setItem:    (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear:      () => { store = {}; },
   };
 })();
 
-Object.defineProperty(window, "localStorage", {
-  value: localStorageMock,
-});
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
 
 // Mock wallet
 const mockFreighter = {
-  isConnected: jest.fn(),
+  isConnected:   jest.fn(),
   requestAccess: jest.fn(),
-  getPublicKey: jest.fn(),
+  getPublicKey:  jest.fn(),
 };
 
 describe("WalletContext", () => {
   beforeEach(() => {
     localStorageMock.clear();
     jest.clearAllMocks();
-    (window as Window & { freighter?: typeof mockFreighter }).freighter = mockFreighter;
+    (window as Window & { freighter?: typeof mockFreighter }).freighter =
+      mockFreighter;
   });
 
   afterEach(() => {
     delete (window as Window & { freighter?: typeof mockFreighter }).freighter;
   });
 
+  // ── Existing tests ────────────────────────────────────────────────────────
+
   it("should initialize with disconnected state", () => {
-    const { result } = renderHook(() => useWallet(), {
-      wrapper: WalletProvider,
-    });
+    const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
 
     expect(result.current.isConnected).toBe(false);
     expect(result.current.publicKey).toBeNull();
@@ -60,97 +58,76 @@ describe("WalletContext", () => {
     mockFreighter.isConnected.mockResolvedValue(false);
     mockFreighter.requestAccess.mockResolvedValue("GTEST123");
 
-    const { result } = renderHook(() => useWallet(), {
-      wrapper: WalletProvider,
-    });
+    const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
 
-    await act(async () => {
-      await result.current.connect();
-    });
+    await act(async () => { await result.current.connect(); });
 
     expect(result.current.isConnected).toBe(true);
     expect(result.current.publicKey).toBe("GTEST123");
-    expect(localStorageMock.getItem("wallet_connected")).toBe("true");
-    expect(localStorageMock.getItem("wallet_public_key")).toBe("GTEST123");
+    expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED)).toBe("true");
+    expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY)).toBe("GTEST123");
+    // connector_id written on connect
+    expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID)).toBeTruthy();
   });
 
   it("should handle wallet connection error", async () => {
     mockFreighter.isConnected.mockResolvedValue(false);
     mockFreighter.requestAccess.mockRejectedValue(new Error("User rejected"));
 
-    const { result } = renderHook(() => useWallet(), {
-      wrapper: WalletProvider,
-    });
+    const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
 
-    await act(async () => {
-      await result.current.connect();
-    });
+    await act(async () => { await result.current.connect(); });
 
     expect(result.current.isConnected).toBe(false);
     expect(result.current.error).toBe("User rejected");
   });
 
-  it("should disconnect wallet and clear state", async () => {
+  it("should disconnect wallet and clear ALL wallet keys including wallet_connector_id", async () => {
     mockFreighter.isConnected.mockResolvedValue(false);
     mockFreighter.requestAccess.mockResolvedValue("GTEST123");
 
-    const { result } = renderHook(() => useWallet(), {
-      wrapper: WalletProvider,
-    });
+    const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
 
-    // Connect first
-    await act(async () => {
-      await result.current.connect();
-    });
-
+    await act(async () => { await result.current.connect(); });
     expect(result.current.isConnected).toBe(true);
 
-    // Disconnect
-    await act(async () => {
-      await result.current.disconnect();
-    });
+    await act(async () => { await result.current.disconnect(); });
 
     expect(result.current.isConnected).toBe(false);
     expect(result.current.publicKey).toBeNull();
-    expect(localStorageMock.getItem("wallet_connected")).toBeNull();
-    expect(localStorageMock.getItem("wallet_public_key")).toBeNull();
+    // All three wallet keys must be gone
+    expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED)).toBeNull();
+    expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY)).toBeNull();
+    expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID)).toBeNull();
   });
 
-  it("should handle wallet disconnection event", async () => {
+  it("should handle wallet disconnection event and clear ALL wallet keys", async () => {
     mockFreighter.isConnected.mockResolvedValue(false);
     mockFreighter.requestAccess.mockResolvedValue("GTEST123");
 
-    const { result } = renderHook(() => useWallet(), {
-      wrapper: WalletProvider,
-    });
+    const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
 
-    // Connect first
-    await act(async () => {
-      await result.current.connect();
-    });
-
+    await act(async () => { await result.current.connect(); });
     expect(result.current.isConnected).toBe(true);
 
-    // Simulate wallet disconnection event
-    act(() => {
-      window.dispatchEvent(new Event("wallet_disconnected"));
-    });
+    act(() => { window.dispatchEvent(new Event("wallet_disconnected")); });
 
     await waitFor(() => {
       expect(result.current.isConnected).toBe(false);
       expect(result.current.publicKey).toBeNull();
+      // wallet_connector_id must also be cleared by the event handler
+      expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID)).toBeNull();
     });
   });
 
-  it("should restore connection from localStorage", async () => {
-    localStorageMock.setItem("wallet_connected", "true");
-    localStorageMock.setItem("wallet_public_key", "GTEST123");
+  it("should restore connection from localStorage including connector_id", async () => {
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED,    "true");
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY,   "GTEST123");
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID, "freighter");
     mockFreighter.isConnected.mockResolvedValue(true);
     mockFreighter.getPublicKey.mockResolvedValue("GTEST123");
 
-    const { result } = renderHook(() => useWallet(), {
-      wrapper: WalletProvider,
-    });
+    const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
 
     await waitFor(() => {
       expect(result.current.isConnected).toBe(true);
@@ -158,17 +135,61 @@ describe("WalletContext", () => {
     });
   });
 
-  it("should clear localStorage if wallet is no longer connected", async () => {
-    localStorageMock.setItem("wallet_connected", "true");
-    localStorageMock.setItem("wallet_public_key", "GTEST123");
+  it("should clear ALL wallet keys if wallet is no longer connected on mount", async () => {
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED,    "true");
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY,   "GTEST123");
+    localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID, "freighter");
     mockFreighter.isConnected.mockResolvedValue(false);
 
-    renderHook(() => useWallet(), {
-      wrapper: WalletProvider,
-    });
+    renderHook(() => useWallet(), { wrapper: WalletProvider });
 
     await waitFor(() => {
-      expect(localStorageMock.getItem("wallet_connected")).toBeNull();
+      expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED)).toBeNull();
+      expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY)).toBeNull();
+      expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID)).toBeNull();
+    });
+  });
+
+  // ── New tests for issue #99 ───────────────────────────────────────────────
+
+  describe("WALLET_STORAGE_KEYS", () => {
+    it("contains exactly the three expected key strings", () => {
+      expect(WALLET_STORAGE_KEYS.WALLET_CONNECTED).toBe("wallet_connected");
+      expect(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY).toBe("wallet_public_key");
+      expect(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID).toBe("wallet_connector_id");
+    });
+  });
+
+  describe("clearWalletStorage (issue #99)", () => {
+    it("removes all three wallet_ keys in one call", () => {
+      localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTED,    "true");
+      localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_PUBLIC_KEY,   "GFAKE");
+      localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID, "freighter");
+
+      clearWalletStorage();
+
+      Object.values(WALLET_STORAGE_KEYS).forEach((key) => {
+        expect(localStorageMock.getItem(key)).toBeNull();
+      });
+    });
+
+    it("does not touch non-wallet keys like auth_token", () => {
+      localStorageMock.setItem("auth_token",      "tok_abc");
+      localStorageMock.setItem("auth_expires_at", "9999");
+      localStorageMock.setItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID, "freighter");
+
+      clearWalletStorage();
+
+      expect(localStorageMock.getItem("auth_token")).toBe("tok_abc");
+      expect(localStorageMock.getItem("auth_expires_at")).toBe("9999");
+      expect(localStorageMock.getItem(WALLET_STORAGE_KEYS.WALLET_CONNECTOR_ID)).toBeNull();
+    });
+
+    it("is safe to call when keys are already absent (idempotent)", () => {
+      expect(() => clearWalletStorage()).not.toThrow();
+      Object.values(WALLET_STORAGE_KEYS).forEach((key) => {
+        expect(localStorageMock.getItem(key)).toBeNull();
+      });
     });
   });
 });

--- a/frontend/src/app/lib/apiClient.ts
+++ b/frontend/src/app/lib/apiClient.ts
@@ -5,6 +5,10 @@
  * Automatically logs out users when tokens expire or become invalid.
  */
 
+// Delegate wallet key cleanup to WalletContext so the key list
+// can never drift (fixes: wallet_connector_id left stale after 401)
+import { clearWalletStorage } from "@/app/contexts/WalletContext";
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
 interface FetchOptions extends RequestInit {
@@ -20,21 +24,15 @@ export async function apiClient<T = unknown>(
 ): Promise<T> {
   const { requiresAuth = false, headers, ...restOptions } = options;
 
-  // Build headers
   const requestHeaders: Record<string, string> = {
     "Content-Type": "application/json",
   };
 
-  // Merge provided headers
   if (headers) {
     if (headers instanceof Headers) {
-      headers.forEach((value, key) => {
-        requestHeaders[key] = value;
-      });
+      headers.forEach((value, key) => { requestHeaders[key] = value; });
     } else if (Array.isArray(headers)) {
-      headers.forEach(([key, value]) => {
-        requestHeaders[key] = value;
-      });
+      headers.forEach(([key, value]) => { requestHeaders[key] = value; });
     } else {
       Object.entries(headers).forEach(([key, value]) => {
         requestHeaders[key] = value;
@@ -42,7 +40,6 @@ export async function apiClient<T = unknown>(
     }
   }
 
-  // Add auth token if required
   if (requiresAuth) {
     const token = localStorage.getItem("auth_token");
     if (token) {
@@ -60,19 +57,20 @@ export async function apiClient<T = unknown>(
 
     // Handle 401 Unauthorized - token expired or invalid
     if (response.status === 401) {
-      // Clear auth state
+      // Clear auth keys
       localStorage.removeItem("auth_token");
       localStorage.removeItem("auth_expires_at");
-      localStorage.removeItem("wallet_connected");
-      localStorage.removeItem("wallet_public_key");
 
-      // Dispatch custom event for auth context to handle
+      // Delegate wallet cleanup — clears wallet_connected,
+      // wallet_public_key AND wallet_connector_id (was missing before)
+      clearWalletStorage();
+
+      // Let AuthContext handle redirect + wallet disconnect
       window.dispatchEvent(new CustomEvent("auth_session_expired"));
 
       throw new Error("Session expired. Please log in again.");
     }
 
-    // Handle other error responses
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
       throw new Error(
@@ -80,17 +78,12 @@ export async function apiClient<T = unknown>(
       );
     }
 
-    // Parse and return response
     return await response.json();
   } catch (error) {
-    // Re-throw for caller to handle
     throw error;
   }
 }
 
-/**
- * Convenience methods for common HTTP verbs
- */
 export const api = {
   get: <T = unknown>(endpoint: string, options?: FetchOptions) =>
     apiClient<T>(endpoint, { ...options, method: "GET" }),


### PR DESCRIPTION
### Problem

On a 401 response, `apiClient.ts` was manually removing `auth_token`, `auth_expires_at`, `wallet_connected`, and `wallet_public_key` — but **not** `wallet_connector_id`.

`WalletContext` always writes and clears all three `wallet_` keys together, so after a 401 the stale `wallet_connector_id` remained in localStorage. On the next mount, the restore logic could read an inconsistent mix of keys, causing a mismatch.

### Solution

- Exported `WALLET_STORAGE_KEYS` (single source of truth for all wallet key strings) and `clearWalletStorage()` (removes all three wallet keys atomically) from `WalletContext.tsx`
- Replaced every hardcoded `localStorage` string literal in `WalletContext` with the new constants
- Updated `apiClient.ts` 401 handler to call `clearWalletStorage()` instead of maintaining its own partial key list — `wallet_connector_id` is now always cleared
- `AuthContext.logout()` already calls `disconnectWallet()` which calls `clearWalletStorage()`, so the full cleanup chain is consistent end-to-end

### Files Changed

- `frontend/src/app/contexts/WalletContext.tsx` — added `WALLET_STORAGE_KEYS` + `clearWalletStorage()` exports, replaced all hardcoded strings
- `frontend/src/app/lib/apiClient.ts` — 401 handler now delegates to `clearWalletStorage()`
- `frontend/src/app/contexts/__tests__/WalletContext.test.tsx` — added `wallet_connector_id` assertions to existing tests + new `clearWalletStorage` describe block
- `frontend/src/app/contexts/__tests__/AuthContext.test.tsx` — `auth_session_expired` test now seeds and asserts all three wallet keys are cleared

### Tests Added / Updated

- `disconnect` test: asserts `wallet_connector_id` is null after disconnect
- `wallet_disconnected` event test: asserts `wallet_connector_id` cleared by event handler
- Mount restore test: seeds `wallet_connector_id` and asserts full clear on stale state
- `clearWalletStorage` unit tests: all three keys removed, non-wallet keys untouched, idempotent when keys absent
- `auth_session_expired` test: seeds all wallet keys, asserts none survive after session expiry

### Acceptance Criteria (from issue #99)

- [x] 401 handling clears `wallet_connector_id` along with other wallet/auth keys
- [x] Storage key cleanup is centralised so it cannot drift from `WalletContext`/`AuthContext`
- [x] A test covers that no stale `wallet_` key survives a 401

Closes #99