### PR TITLE
fix: add INTERNAL_API_KEY, PORT, NODE_ENV to .env.example and documen…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,19 @@
-CORS_ALLOWED_ORIGINS=http://localhost:3000
+# Server configuration
+PORT=3001
+NODE_ENV=development
+
+# API Security
+# Internal API key for server-to-server communication
+# Required by the /api/score/update endpoint to verify requests from trusted services
+INTERNAL_API_KEY=your-internal-api-key-here
+
+# Database
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/remitlend
+
+# CORS configuration
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+
+# API Key for internal service authentication
+# Required for score update endpoints (e.g., /api/score/update)
+# Used in middleware/auth.ts to validate x-api-key header
+INTERNAL_API_KEY=your-secret-api-key-here

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,6 +5,7 @@ Express.js backend service for the RemitLend platform, providing API endpoints f
 ## Overview
 
 The backend serves as a bridge between the frontend application and the Stellar blockchain, handling:
+
 - Credit score generation and verification
 - Remittance history simulation (for MVP)
 - NFT metadata provision
@@ -43,19 +44,21 @@ npm run dev
 
 ### Environment Variables
 
-Create a `.env` file in the backend directory:
+Create a `.env` file in the backend directory. Copy from `.env.example` and fill in any required values:
 
-```env
-# Server Configuration
-PORT=3001
-
-# CORS Configuration
-CORS_ALLOWED_ORIGINS=http://localhost:3000
-
-# Future: Add API keys for remittance services
-# WISE_API_KEY=your_key_here
-# WESTERN_UNION_API_KEY=your_key_here
+```bash
+cp .env.example .env
 ```
+
+Required variables:
+
+| Variable               | Description                                                   | Example                             |
+| ---------------------- | ------------------------------------------------------------- | ----------------------------------- |
+| `PORT`                 | Server port                                                   | `3001`                              |
+| `NODE_ENV`             | Environment mode (development/production)                     | `development`                       |
+| `INTERNAL_API_KEY`     | API key for server-to-server auth on mutating score endpoints | `your-secret-key-here`              |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins                  | `http://localhost:3000`             |
+| `DATABASE_URL`         | PostgreSQL connection string                                  | `postgres://user:pass@host:5432/db` |
 
 ## Available Scripts
 
@@ -88,6 +91,7 @@ npm run format:check # Check code formatting
 Check if the API is running.
 
 **Response:**
+
 ```json
 {
   "status": "ok",
@@ -102,9 +106,11 @@ Check if the API is running.
 Get the credit score for a specific user based on their remittance history.
 
 **Parameters:**
+
 - `userId` (string) - User identifier
 
 **Response:**
+
 ```json
 {
   "userId": "user123",
@@ -119,6 +125,7 @@ Get the credit score for a specific user based on their remittance history.
 ```
 
 **Error Responses:**
+
 - `400` - Invalid user ID
 - `404` - User not found
 - `500` - Server error
@@ -130,6 +137,7 @@ Get the credit score for a specific user based on their remittance history.
 Simulate remittance history for testing purposes.
 
 **Request Body:**
+
 ```json
 {
   "userId": "user123",
@@ -144,6 +152,7 @@ Simulate remittance history for testing purposes.
 ```
 
 **Response:**
+
 ```json
 {
   "userId": "user123",
@@ -159,6 +168,7 @@ Interactive API documentation is available via Swagger UI when the server is run
 **URL**: [http://localhost:3001/api-docs](http://localhost:3001/api-docs)
 
 The Swagger documentation provides:
+
 - Complete endpoint specifications
 - Request/response schemas
 - Interactive API testing
@@ -210,7 +220,7 @@ backend/
 Centralized error handling middleware that catches and formats errors.
 
 ```typescript
-import { errorHandler } from './middleware/errorHandler';
+import { errorHandler } from "./middleware/errorHandler";
 app.use(errorHandler);
 ```
 
@@ -219,10 +229,10 @@ app.use(errorHandler);
 Request validation using Zod schemas.
 
 ```typescript
-import { validate } from './middleware/validation';
-import { mySchema } from './schemas/mySchemas';
+import { validate } from "./middleware/validation";
+import { mySchema } from "./schemas/mySchemas";
 
-router.post('/endpoint', validate(mySchema), controller);
+router.post("/endpoint", validate(mySchema), controller);
 ```
 
 ### Rate Limiter
@@ -230,8 +240,8 @@ router.post('/endpoint', validate(mySchema), controller);
 Protects endpoints from abuse with configurable rate limits.
 
 ```typescript
-import { rateLimiter } from './middleware/rateLimiter';
-app.use('/api/', rateLimiter);
+import { rateLimiter } from "./middleware/rateLimiter";
+app.use("/api/", rateLimiter);
 ```
 
 ### Async Handler
@@ -239,11 +249,14 @@ app.use('/api/', rateLimiter);
 Wraps async route handlers to catch errors automatically.
 
 ```typescript
-import { asyncHandler } from './middleware/asyncHandler';
+import { asyncHandler } from "./middleware/asyncHandler";
 
-router.get('/endpoint', asyncHandler(async (req, res) => {
-  // Async code here
-}));
+router.get(
+  "/endpoint",
+  asyncHandler(async (req, res) => {
+    // Async code here
+  }),
+);
 ```
 
 ## Testing
@@ -267,16 +280,14 @@ npm test -- --watch
 ### Test Structure
 
 ```typescript
-import request from 'supertest';
-import app from '../app';
+import request from "supertest";
+import app from "../app";
 
-describe('GET /api/health', () => {
-  it('should return 200 OK', async () => {
-    const response = await request(app)
-      .get('/api/health')
-      .expect(200);
-    
-    expect(response.body).toHaveProperty('status', 'ok');
+describe("GET /api/health", () => {
+  it("should return 200 OK", async () => {
+    const response = await request(app).get("/api/health").expect(200);
+
+    expect(response.body).toHaveProperty("status", "ok");
   });
 });
 ```
@@ -284,6 +295,7 @@ describe('GET /api/health', () => {
 ### Test Coverage
 
 Aim for >80% code coverage on new code. Current coverage:
+
 - Statements: Check with `npm test -- --coverage`
 - Branches: Check with `npm test -- --coverage`
 - Functions: Check with `npm test -- --coverage`
@@ -294,9 +306,9 @@ Aim for >80% code coverage on new code. Current coverage:
 ### Custom Error Class
 
 ```typescript
-import { AppError } from './errors/AppError';
+import { AppError } from "./errors/AppError";
 
-throw new AppError('User not found', 404);
+throw new AppError("User not found", 404);
 ```
 
 ### Error Response Format
@@ -317,22 +329,24 @@ Validation schemas are defined using Zod in the `schemas/` directory.
 ### Example Schema
 
 ```typescript
-import { z } from 'zod';
+import { z } from "zod";
 
 export const getUserScoreSchema = z.object({
   params: z.object({
-    userId: z.string().min(1, 'User ID is required'),
+    userId: z.string().min(1, "User ID is required"),
   }),
 });
 
 export const simulateRemittanceSchema = z.object({
   body: z.object({
     userId: z.string().min(1),
-    transactions: z.array(z.object({
-      amount: z.number().positive(),
-      date: z.string(),
-      recipient: z.string(),
-    })),
+    transactions: z.array(
+      z.object({
+        amount: z.number().positive(),
+        date: z.string(),
+        recipient: z.string(),
+      }),
+    ),
   }),
 });
 ```
@@ -340,18 +354,21 @@ export const simulateRemittanceSchema = z.object({
 ## Future Enhancements
 
 ### Phase 1: Real Remittance Integration
+
 - [ ] Wise API integration
 - [ ] Western Union API integration
 - [ ] Remittance data verification
 - [ ] Historical data import
 
 ### Phase 2: Enhanced Features
+
 - [ ] User authentication (JWT)
 - [ ] Database integration (PostgreSQL)
 - [ ] IPFS integration for NFT metadata
 - [ ] Webhook support for blockchain events
 
 ### Phase 3: Production Ready
+
 - [ ] Caching layer (Redis)
 - [ ] Logging and monitoring
 - [ ] CI/CD pipeline


### PR DESCRIPTION
# Fix: Add missing environment variables to .env.example and README

## Description
Adds the missing environment variables `INTERNAL_API_KEY`, `PORT`, and `NODE_ENV` to `.env.example` with sensible defaults and documentation. Also enhances the README with a comprehensive table of all required environment variables.

## Fixes
Closes #95

## Changes
- Updated `backend/.env.example` to include all environment variables used by the backend
- Added `INTERNAL_API_KEY` with clear comments explaining its use in API key authentication
- Organized variables into logical groups (Server Configuration, API Security, Database, CORS)
- Enhanced `backend/README.md` with a requirements table documenting all variables

## Acceptance Criteria ✅
- [x] `.env.example` includes `INTERNAL_API_KEY`, `PORT`, and `NODE_ENV` with sensible defaults
- [x] Every `process.env` key the backend reads is represented in `.env.example`
- [x] README mentions the required variables with descriptions and examples

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
Verified that all environment variables referenced in the codebase are now documented:
- `PORT` - used in `src/index.ts`
- `NODE_ENV` - used in `src/middleware/errorHandler.ts`
- `INTERNAL_API_KEY` - used in `src/middleware/auth.ts`
- `CORS_ALLOWED_ORIGINS` - used in `src/app.ts`
- `DATABASE_URL` - used in database configuration

## Screenshots (if applicable)
N/A

closes #95