### PR TITLE
 Enforce Minimum Remittance NFT Score for Loan Requests

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, IntoVal};
 
 mod events;
+
+const MIN_SCORE: u32 = 50;
 
 #[contracttype]
 #[derive(Clone)]
@@ -21,14 +23,21 @@ impl LoanManager {
     }
 
     pub fn request_loan(env: Env, borrower: Address, amount: i128) {
-        let _nft_contract: Address = env
+        let nft_contract: Address = env
             .storage()
             .instance()
             .get(&DataKey::NftContract)
             .expect("not initialized");
 
-        // For now, just assume all borrowers have sufficient score
-        // In a real implementation, you'd call the NFT contract to get the score
+        let score: u32 = env.invoke_contract(
+            &nft_contract,
+            &Symbol::new(&env, "get_score"),
+            soroban_sdk::vec![&env, borrower.into_val(&env)],
+        );
+
+        if score < MIN_SCORE {
+            panic!("borrower score below threshold");
+        }
 
         if amount <= 0 {
             panic!("loan amount must be positive");

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol, IntoVal};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, IntoVal, Symbol};
 
 mod events;
 

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -1,5 +1,19 @@
 use crate::{LoanManager, LoanManagerClient};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env};
+
+#[contract]
+pub struct MockNftContract;
+
+#[contractimpl]
+impl MockNftContract {
+    pub fn get_score(env: Env, user: Address) -> u32 {
+        env.storage().instance().get(&user).unwrap_or(0)
+    }
+
+    pub fn set_score(env: Env, user: Address, score: u32) {
+        env.storage().instance().set(&user, &score);
+    }
+}
 
 #[test]
 fn test_loan_request_success() {
@@ -9,12 +23,34 @@ fn test_loan_request_success() {
     let loan_manager_id = env.register(LoanManager, ());
     let manager = LoanManagerClient::new(&env, &loan_manager_id);
 
-    let nft_contract = Address::generate(&env);
+    let nft_contract = env.register(MockNftContract, ());
+    let nft_client = MockNftContractClient::new(&env, &nft_contract);
     manager.initialize(&nft_contract);
 
     let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
 
     // Should succeed without panicking
+    manager.request_loan(&borrower, &1000);
+}
+
+#[test]
+#[should_panic(expected = "borrower score below threshold")]
+fn test_loan_request_rejected_low_score() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let loan_manager_id = env.register(LoanManager, ());
+    let manager = LoanManagerClient::new(&env, &loan_manager_id);
+
+    let nft_contract = env.register(MockNftContract, ());
+    let nft_client = MockNftContractClient::new(&env, &nft_contract);
+    manager.initialize(&nft_contract);
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &40);
+
+    // Should panic due to low score
     manager.request_loan(&borrower, &1000);
 }
 
@@ -27,10 +63,12 @@ fn test_loan_request_negative_amount() {
     let loan_manager_id = env.register(LoanManager, ());
     let manager = LoanManagerClient::new(&env, &loan_manager_id);
 
-    let nft_contract = Address::generate(&env);
+    let nft_contract = env.register(MockNftContract, ());
+    let nft_client = MockNftContractClient::new(&env, &nft_contract);
     manager.initialize(&nft_contract);
 
     let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
 
     // Should panic due to negative amount
     manager.request_loan(&borrower, &-100);


### PR DESCRIPTION
Closes #88

## Why this matters
Previously, `request_loan` loaded the `NftContract` address but never actually called it, merely assuming all borrowers had sufficient scores. This PR implements the intended core premise of the project by verifying that a borrower meets a minimum remittance NFT score before allowing a loan request to proceed. This addresses a correctness gap distinct from authorization and loan state machine issues.

## Changes Made
- **`loan_manager/src/lib.rs`**: 
  - Updated `request_loan` to dynamically invoke the `remittance_nft` contract via the stored `NftContract` address using the `get_score` method.
  - Enforced a minimum-score threshold (currently set to 50); the contract explicitly rejects (panics with `"borrower score below threshold"`) if a borrower is below it.
- **`loan_manager/src/test.rs`**: 
  - Integrated a `MockNftContract` within the test suite to simulate the behavior of the remittance NFT.
  - Added new test coverage ensuring a borrower above the threshold is accepted and one below the threshold is rejected.

## Acceptance Criteria Verified
- [x] `request_loan` queries the `remittance_nft` contract for the borrower score via the stored `NftContract` address.
- [x] A minimum-score threshold is enforced and the call rejects when the borrower is below it.
- [x] Tests cover an accepted borrower above the threshold and a rejected borrower below it.

