### PR TITLE
fix: compute simulatePayment newScore from inputs instead of hardcode…

### DIFF
--- a/backend/src/__tests__/simulation.test.ts
+++ b/backend/src/__tests__/simulation.test.ts
@@ -1,0 +1,142 @@
+import request from "supertest";
+import app from "../app.js";
+
+// ---------------------------------------------------------------------------
+// GET /api/history/:userId
+// ---------------------------------------------------------------------------
+describe("GET /api/history/:userId", () => {
+  it("returns score, streak, and history for a valid userId", async () => {
+    const res = await request(app).get("/api/history/user123");
+    expect(res.status).toBe(200);
+    expect(res.body.userId).toBe("user123");
+    expect(typeof res.body.score).toBe("number");
+    expect(typeof res.body.streak).toBe("number");
+    expect(Array.isArray(res.body.history)).toBe(true);
+    expect(res.body.history.length).toBeGreaterThan(0);
+  });
+
+  it("score is derived from history, not a fixed literal", async () => {
+    const res = await request(app).get("/api/history/alice");
+    expect(res.status).toBe(200);
+    // score must be in the valid credit-score range
+    expect(res.body.score).toBeGreaterThanOrEqual(500);
+    expect(res.body.score).toBeLessThanOrEqual(850);
+    // streak must equal the number of history rows (all completed)
+    expect(res.body.streak).toBe(res.body.history.length);
+  });
+
+  it("different users get different scores and history", async () => {
+    const r1 = await request(app).get("/api/history/alice");
+    const r2 = await request(app).get("/api/history/bob");
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    // At least one of score or history amount should differ
+    const sameScore = r1.body.score === r2.body.score;
+    const sameFirstAmount =
+      r1.body.history[0]?.amount === r2.body.history[0]?.amount;
+    expect(sameScore && sameFirstAmount).toBe(false);
+  });
+
+  it("same user always gets the same deterministic result", async () => {
+    const r1 = await request(app).get("/api/history/carol");
+    const r2 = await request(app).get("/api/history/carol");
+    expect(r1.body.score).toBe(r2.body.score);
+    expect(r1.body.streak).toBe(r2.body.streak);
+    expect(r1.body.history[0].amount).toBe(r2.body.history[0].amount);
+  });
+
+  it("returns 400 for missing userId", async () => {
+    const res = await request(app).get("/api/history/");
+    expect(res.status).toBe(404); // route not matched
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/simulate
+// ---------------------------------------------------------------------------
+describe("POST /api/simulate", () => {
+  it("returns success with a computed newScore", async () => {
+    const res = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "user123", amount: 500 });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.newScore).toBe("number");
+    expect(typeof res.body.currentScore).toBe("number");
+    expect(typeof res.body.scoreDelta).toBe("number");
+  });
+
+  it("newScore is greater than currentScore (payment boosts score)", async () => {
+    const res = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "user123", amount: 500 });
+    expect(res.status).toBe(200);
+    expect(res.body.newScore).toBeGreaterThan(res.body.currentScore);
+  });
+
+  it("larger amount produces a larger score boost", async () => {
+    const small = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "alice", amount: 50 });
+    const large = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "alice", amount: 1000 });
+    expect(small.status).toBe(200);
+    expect(large.status).toBe(200);
+    expect(large.body.scoreDelta).toBeGreaterThan(small.body.scoreDelta);
+  });
+
+  it("newScore varies with userId (different base scores)", async () => {
+    const r1 = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "alice", amount: 500 });
+    const r2 = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "bob", amount: 500 });
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    // Different users have different base scores so newScore differs
+    expect(r1.body.newScore).not.toBe(r2.body.newScore);
+  });
+
+  it("newScore never exceeds 850", async () => {
+    const res = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "highscore", amount: 1000000 });
+    expect(res.status).toBe(200);
+    expect(res.body.newScore).toBeLessThanOrEqual(850);
+  });
+
+  it("newScore is never the hardcoded constant 760 for all inputs", async () => {
+    const r1 = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "alice", amount: 100 });
+    const r2 = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "dave", amount: 900 });
+    // At least one result must differ from 760 (the old hardcoded value)
+    const bothAre760 = r1.body.newScore === 760 && r2.body.newScore === 760;
+    expect(bothAre760).toBe(false);
+  });
+
+  it("returns 400 for missing amount", async () => {
+    const res = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "user123" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 or 429 for negative amount", async () => {
+    const res = await request(app)
+      .post("/api/simulate")
+      .send({ userId: "user123", amount: -100 });
+    expect([400, 429]).toContain(res.status);
+  });
+
+  it("returns 400 or 429 for missing userId", async () => {
+    const res = await request(app)
+      .post("/api/simulate")
+      .send({ amount: 500 });
+    expect([400, 429]).toContain(res.status);
+  });
+  });

--- a/backend/src/controllers/simulationController.ts
+++ b/backend/src/controllers/simulationController.ts
@@ -1,20 +1,83 @@
 import type { Request, Response } from "express";
 import { asyncHandler } from "../middleware/asyncHandler.js";
 
+// ── Score computation helpers ────────────────────────────────────────────────
+
+/**
+ * Derive a deterministic base score from a userId string.
+ * Uses the same simple hash approach as the existing score controller so
+ * the simulation is consistent with what a user would see on their profile.
+ * Range: 500–850 (standard credit-score band).
+ */
+function baseScoreForUser(userId: string): number {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  return 500 + (hash % 351); // 500–850
+}
+
+/**
+ * Compute the score delta from a single payment simulation.
+ *
+ * Rules (all capped so the result stays within 500–850):
+ *  - Every payment adds a base +5 points (on-time payment boost).
+ *  - An additional +1 point per $100 paid, up to +15 (larger payments
+ *    signal stronger repayment capacity, but with diminishing returns).
+ *  - Total max boost per simulation: +20 points.
+ */
+function computeScoreDelta(amount: number): number {
+  const baseBoost = 5;
+  const amountBoost = Math.min(15, Math.floor(amount / 100));
+  return baseBoost + amountBoost;
+}
+
+// ── Controllers ──────────────────────────────────────────────────────────────
+
 export const getRemittanceHistory = asyncHandler(
   async (req: Request, res: Response) => {
     const { userId } = req.params;
-    // Mock data simulation
-    const history = [
-      { month: "January", amount: 500, status: "Completed" },
-      { month: "February", amount: 500, status: "Completed" },
-      { month: "March", amount: 500, status: "Completed" },
+
+    // Generate a deterministic history based on userId so the same user
+    // always gets the same mock history (consistent with the score endpoint).
+    const base = baseScoreForUser(userId);
+    const amounts = [200, 350, 500, 750, 1000];
+    const months = [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
     ];
+
+    // Derive 3 history rows from the userId hash so the data varies per user.
+    let hash = 0;
+    for (let i = 0; i < userId.length; i++) {
+      hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+    }
+
+    const history = [0, 1, 2].map((offset) => ({
+      month: months[(hash + offset) % 12],
+      amount: amounts[(hash + offset) % amounts.length],
+      status: "Completed",
+    }));
+
+    // Derive score and streak from the history rather than fixed literals.
+    const streak = history.length; // all completed
+    const totalPaid = history.reduce((sum, row) => sum + row.amount, 0);
+    const score = Math.min(850, base + Math.floor(totalPaid / 100));
 
     res.json({
       userId,
-      score: 750,
-      streak: 3,
+      score,
+      streak,
       history,
     });
   },
@@ -23,11 +86,17 @@ export const getRemittanceHistory = asyncHandler(
 export const simulatePayment = asyncHandler(
   async (req: Request, res: Response) => {
     const { userId, amount } = req.body;
-    // Simulate payment logic
+
+    const currentScore = baseScoreForUser(userId);
+    const delta = computeScoreDelta(amount);
+    const newScore = Math.min(850, currentScore + delta);
+
     res.json({
       success: true,
       message: `Payment of ${amount} for user ${userId} simulated.`,
-      newScore: 760,
+      currentScore,
+      newScore,
+      scoreDelta: delta,
     });
   },
 );


### PR DESCRIPTION
## What does this PR do?
Fixes `simulatePayment` and `getRemittanceHistory` to compute meaningful, input-dependent results instead of returning hardcoded constants.

## Why?
Closes #98 — `simulatePayment` always returned `newScore: 760` regardless of userId or amount, and `getRemittanceHistory` always returned `score: 750` and 3 identical static rows. This is misleading for any client relying on the simulation endpoint.

## Changes

### `backend/src/controllers/simulationController.ts`

**`simulatePayment`:**
- Derives `currentScore` from userId via a deterministic hash (500–850 range, consistent with the score endpoint)
- Computes `scoreDelta` from amount: +5 base boost + up to +15 for larger payments, capped at 850
- Response now includes `currentScore`, `newScore`, and `scoreDelta`

**`getRemittanceHistory`:**
- Score is derived from the user's base score + total amount paid across history rows (no longer fixed at 750)
- Streak equals the number of completed history rows (no longer fixed at 3)
- History rows are generated deterministically per userId so responses vary across users but remain consistent for the same user

## Tests

### `backend/src/__tests__/simulation.test.ts` (new — 13 tests)
- `newScore` varies with userId and amount (not hardcoded to 760)
- Larger amounts produce larger score boosts
- `newScore` never exceeds 850
- Different users get different scores and history
- Same user always gets deterministic results
- Invalid inputs return 400/429

## Test results