### PR TITLE
ci: use npm ci for frontend and cache on package-lock.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-          cache-dependency-path: frontend/package.json
+          cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: frontend
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## Description
This PR addresses an issue where the frontend CI workflow used `npm install`, which could inadvertently mutate the lockfile and resolve inconsistent transitive dependency versions across runs. It also corrects the node caching target, ensuring it points to the lockfile.

## Changes
- Updated the `.github/workflows/ci.yml` frontend job to run `npm ci` instead of `npm install`. This natively ensures that the CI fails correctly if `package-lock.json` is out of sync rather than silently rewriting it.
- Changed the `cache-dependency-path` for `actions/setup-node` to point to `frontend/package-lock.json`, mirroring the backend setup and ensuring cache hits match the lockfile correctly.

closes #93 