### PR TITLE
fix(backend): make rate limiter reliable behind a proxy

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,7 @@
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/remitlend
+# Number of proxy hops to trust for client IP resolution (rate limiting).
+# Set to 1 behind a single reverse proxy / load balancer; leave unset for
+# direct (non-proxied) deployments. Accepts a hop count, true/false, or a
+# subnet/preset list (e.g. "loopback, 10.0.0.0/8").
+TRUST_PROXY=

--- a/backend/src/__tests__/rateLimiter.test.ts
+++ b/backend/src/__tests__/rateLimiter.test.ts
@@ -1,0 +1,92 @@
+import express from "express";
+import request from "supertest";
+import { createRateLimiter } from "../middleware/rateLimiter.js";
+import { parseTrustProxy } from "../config/trustProxy.js";
+
+/**
+ * Builds a minimal app with a low rate limit so the limiter can be exercised in
+ * a few requests. `trustProxy` mirrors what `app.set("trust proxy", ...)` does
+ * in the real app, letting us assert how client IPs are derived behind a proxy.
+ */
+const buildApp = (trustProxy: boolean | number, max: number) => {
+  const app = express();
+  app.set("trust proxy", trustProxy);
+  app.use(
+    createRateLimiter(max, 15, {
+      // Silence validation noise from sending X-Forwarded-For in tests; the
+      // behaviour under test is the keying, which we assert via status codes.
+      validate: false,
+    }),
+  );
+  app.get("/", (_req, res) => res.status(200).json({ ok: true }));
+  return app;
+};
+
+describe("rateLimiter", () => {
+  describe("per-client keying behind a proxy", () => {
+    it("gives each forwarded client IP its own bucket when trust proxy is set", async () => {
+      const app = buildApp(1, 2); // trust 1 hop, allow 2 requests per IP
+
+      // Client A exhausts its bucket.
+      await request(app).get("/").set("X-Forwarded-For", "1.1.1.1").expect(200);
+      await request(app).get("/").set("X-Forwarded-For", "1.1.1.1").expect(200);
+      await request(app).get("/").set("X-Forwarded-For", "1.1.1.1").expect(429);
+
+      // Client B is unaffected — it has its own bucket, proving limits apply
+      // per client rather than globally behind the proxy.
+      await request(app).get("/").set("X-Forwarded-For", "2.2.2.2").expect(200);
+      await request(app).get("/").set("X-Forwarded-For", "2.2.2.2").expect(200);
+      await request(app).get("/").set("X-Forwarded-For", "2.2.2.2").expect(429);
+    });
+
+    it("lumps all forwarded clients into one bucket when trust proxy is off", async () => {
+      const app = buildApp(false, 2); // do not trust the proxy
+
+      // Without trust proxy, req.ip is the (shared) socket address, so distinct
+      // forwarded clients drain the SAME bucket — the broken behaviour we fix.
+      await request(app).get("/").set("X-Forwarded-For", "1.1.1.1").expect(200);
+      await request(app).get("/").set("X-Forwarded-For", "2.2.2.2").expect(200);
+      await request(app).get("/").set("X-Forwarded-For", "3.3.3.3").expect(429);
+    });
+  });
+
+  describe("standard headers", () => {
+    it("emits draft RateLimit-* headers and omits legacy X-RateLimit-* headers", async () => {
+      const app = buildApp(1, 5);
+
+      const res = await request(app)
+        .get("/")
+        .set("X-Forwarded-For", "9.9.9.9")
+        .expect(200);
+
+      expect(res.headers).toHaveProperty("ratelimit-limit");
+      expect(res.headers).toHaveProperty("ratelimit-remaining");
+      expect(res.headers).not.toHaveProperty("x-ratelimit-limit");
+    });
+  });
+
+  describe("parseTrustProxy", () => {
+    it("defaults to false when unset or empty", () => {
+      expect(parseTrustProxy(undefined)).toBe(false);
+      expect(parseTrustProxy("")).toBe(false);
+      expect(parseTrustProxy("   ")).toBe(false);
+    });
+
+    it("parses booleans case-insensitively", () => {
+      expect(parseTrustProxy("true")).toBe(true);
+      expect(parseTrustProxy("TRUE")).toBe(true);
+      expect(parseTrustProxy("false")).toBe(false);
+    });
+
+    it("parses a non-negative integer hop count", () => {
+      expect(parseTrustProxy("1")).toBe(1);
+      expect(parseTrustProxy("0")).toBe(0);
+    });
+
+    it("passes through subnet/preset strings verbatim", () => {
+      expect(parseTrustProxy("loopback, 10.0.0.0/8")).toBe(
+        "loopback, 10.0.0.0/8",
+      );
+    });
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,8 +14,16 @@ import { swaggerSpec } from "./config/swagger.js";
 import { globalRateLimiter } from "./middleware/rateLimiter.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { AppError } from "./errors/AppError.js";
+import { parseTrustProxy } from "./config/trustProxy.js";
 
 const app = express();
+
+// Configure how many proxy hops to trust so that `req.ip` (and therefore
+// per-IP rate limiting) resolves to the real client behind a load balancer /
+// reverse proxy instead of the proxy's address. Controlled via the
+// `TRUST_PROXY` env var; defaults to not trusting any proxy. Must be set
+// before any middleware that relies on `req.ip`.
+app.set("trust proxy", parseTrustProxy(process.env.TRUST_PROXY));
 
 const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS
   ? process.env.CORS_ALLOWED_ORIGINS.split(",").map((origin) => origin.trim())

--- a/backend/src/config/trustProxy.ts
+++ b/backend/src/config/trustProxy.ts
@@ -1,0 +1,39 @@
+/**
+ * Parses the `TRUST_PROXY` environment variable into a value accepted by
+ * Express's `app.set("trust proxy", ...)`.
+ *
+ * Why this matters:
+ *   Behind a reverse proxy / load balancer (e.g. the Docker proxy or a cloud
+ *   LB), the socket address Express sees is the proxy's, not the client's. With
+ *   `trust proxy` configured, Express derives `req.ip` from the
+ *   `X-Forwarded-For` header instead, so per-IP rate limiting keys on the real
+ *   client rather than putting every client into one shared bucket.
+ *
+ * Accepted values (case-insensitive):
+ *   - unset / empty  -> `false` (no proxy trusted; the safe default for direct,
+ *                        non-proxied deployments)
+ *   - "true"         -> `true`  (trust all proxies — convenient but permissive;
+ *                        prefer a hop count instead)
+ *   - "false"        -> `false`
+ *   - a number, e.g. "1"   -> trust that many hops closest to the app. This is
+ *                        the recommended setting behind a single proxy/LB.
+ *   - anything else, e.g. "loopback, 10.0.0.0/8" -> passed through verbatim so
+ *                        Express can interpret it as a subnet / preset list.
+ */
+export const parseTrustProxy = (
+  value: string | undefined,
+): boolean | number | string => {
+  if (value === undefined) return false;
+
+  const trimmed = value.trim();
+  if (trimmed === "") return false;
+
+  const lower = trimmed.toLowerCase();
+  if (lower === "true") return true;
+  if (lower === "false") return false;
+
+  const asNumber = Number(trimmed);
+  if (Number.isInteger(asNumber) && asNumber >= 0) return asNumber;
+
+  return trimmed;
+};

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -1,10 +1,40 @@
 import rateLimit from "express-rate-limit";
 
-export const createRateLimiter = (max: number, windowMinutes: number = 15) =>
+/**
+ * Builds an express-rate-limit middleware.
+ *
+ * Keying:
+ *   The default key generator is used, which keys requests by the client IP
+ *   (`req.ip`). For that IP to be the real client (and not the proxy/load
+ *   balancer) behind a proxy, the app MUST configure `trust proxy` so Express
+ *   derives `req.ip` from the `X-Forwarded-For` header. See `app.ts`.
+ *
+ * Headers:
+ *   `standardHeaders` emits the IETF draft `RateLimit-*` headers so clients can
+ *   see their remaining quota; the deprecated `X-RateLimit-*` headers are
+ *   disabled.
+ *
+ * Store:
+ *   This uses express-rate-limit's default in-memory store. That store is
+ *   per-process, so counters are NOT shared across multiple backend instances:
+ *   each instance enforces its own limit. This is acceptable for a
+ *   single-instance deployment. To enforce a single global limit across
+ *   horizontally-scaled instances, pass a shared `store` (e.g. a Redis-backed
+ *   store) via `options`. Selecting a specific provider is intentionally left
+ *   to the deployment and is out of scope here.
+ */
+export const createRateLimiter = (
+  max: number,
+  windowMinutes: number = 15,
+  options: Partial<Parameters<typeof rateLimit>[0]> = {},
+) =>
   rateLimit({
     windowMs: windowMinutes * 60 * 1000,
     max,
+    standardHeaders: true,
+    legacyHeaders: false,
     message: { error: "Too many requests, please try again later." },
+    ...options,
   });
 
 export const globalRateLimiter = createRateLimiter(100);


### PR DESCRIPTION
# fix(backend): make rate limiter reliable behind a proxy

Closes #96

## Why

`middleware/rateLimiter.ts` used `express-rate-limit` with all-default options (in-memory store, IP keying), and `app.ts` never called `app.set('trust proxy', ...)`. Behind a load balancer or the Docker proxy this means:

- `req.ip` resolves to the **proxy's** address, so every client is keyed into a **single shared bucket** (or `X-Forwarded-For` is ignored entirely) — per-IP limits don't actually apply per IP.
- No `standardHeaders` / `legacyHeaders` configuration, so clients get no rate-limit quota headers.
- The in-memory store is per-process and isn't shared across instances.

This is about the operational correctness of the existing limiter, distinct from #23 (introducing rate limiting).

## What changed

**`backend/src/config/trustProxy.ts`** (new)
- `parseTrustProxy()` turns the `TRUST_PROXY` env var into a value Express accepts: a hop count (`"1"`), a boolean (`"true"`/`"false"`), or a subnet/preset string (`"loopback, 10.0.0.0/8"`). Defaults to `false` (no proxy trusted) when unset/empty.

**`backend/src/app.ts`**
- Calls `app.set("trust proxy", parseTrustProxy(process.env.TRUST_PROXY))` **before** the rate-limit middleware, so `req.ip` (and thus rate-limit keying) resolves to the real client behind a proxy. Configurable per deployment, safe default for direct deployments.

**`backend/src/middleware/rateLimiter.ts`**
- Sets `standardHeaders: true` (IETF draft `RateLimit-*` headers) and `legacyHeaders: false`.
- `createRateLimiter` now accepts an optional `options` object so callers can pass a shared `store` (e.g. Redis) or other overrides.
- Documents that the default store is in-memory and per-process: fine for a single instance, but a shared store is required to enforce one global limit across horizontally-scaled instances. Choosing a specific provider is intentionally left out of scope.

**`backend/.env.example`**
- Documents the new `TRUST_PROXY` variable.

**`backend/src/__tests__/rateLimiter.test.ts`** (new)
- Proves limits apply **per forwarded client** when `trust proxy` is set (client A hitting 429 does not affect client B).
- Demonstrates the broken behaviour for contrast: with trust proxy off, distinct `X-Forwarded-For` clients drain the **same** bucket.
- Asserts draft `RateLimit-*` headers are present and legacy `X-RateLimit-*` headers are absent.
- Unit-tests `parseTrustProxy` for all input forms.

## Deployment note

Set `TRUST_PROXY=1` when running behind a single reverse proxy / load balancer (including the Docker proxy). Leave it unset for direct, non-proxied deployments. Use a higher hop count or a subnet list for multi-proxy chains.

## Testing

- `npm run lint` — clean
- `npm test` — 38 passed (5 suites), including the new rate-limiter suite
- `npm run build` — succeeds

## Out of scope

- Choosing a specific Redis provider / shared-store implementation (the limiter now accepts a `store`, but none is wired up).
