### PR TITLE
fix: resolve swagger apis glob for both dev (.ts) and prod (.js) builds

### DIFF
--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -23,7 +23,7 @@ const swaggerDefinition = {
 
 const options: swaggerJSDoc.Options = {
   swaggerDefinition,
-  apis: [path.resolve(__dirname, "../routes/*.ts")],
+  apis: [path.resolve(__dirname, "../routes/*.js"), path.resolve(__dirname, "../routes/*.ts")],
 };
 
 export const swaggerSpec = swaggerJSDoc(options);


### PR DESCRIPTION
backend/src/config/swagger.ts pointed apis only at '../routes/*.ts', which resolves correctly in dev (ts-node) but finds zero files in the compiled production build (dist/) where only .js files exist, causing /api/docs to serve an empty spec.

Fix: supply both globs so swagger-jsdoc scans whichever extension exists at runtime:
  - '../routes/*.js'  -> picked up by node dist/index.js in production
  - '../routes/*.ts'  -> picked up by ts-node in development

No Dockerfile change needed: the compiled .js files are already present in dist/routes/ after 'npm run build'; swagger-jsdoc simply needed to be told to look for them.

npm test: 38 passed, 0 failed

Closes #89