### PR TITLE
feat(contracts): add repayment calculation logic

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6913,13 +6913,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -6952,6 +6945,49 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -7081,6 +7117,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -2,13 +2,41 @@
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, IntoVal, Symbol};
 
 mod events;
+pub mod repayment;
 
 const MIN_SCORE: u32 = 50;
+const DEFAULT_INTEREST_RATE_BPS: u32 = 1000; // 10% annual
+const DEFAULT_PENALTY_RATE_BPS: u32 = 500; // 5% annual penalty
+const DEFAULT_LOAN_DURATION: u64 = 31_536_000; // 1 year in seconds
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LoanStatus {
+    Requested,
+    Active,
+    Repaid,
+    Defaulted,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Loan {
+    pub borrower: Address,
+    pub principal: i128,
+    pub interest_rate_bps: u32,
+    pub penalty_rate_bps: u32,
+    pub start_time: u64,
+    pub due_time: u64,
+    pub amount_repaid: i128,
+    pub status: LoanStatus,
+}
 
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     NftContract,
+    LoanCount,
+    Loan(u32),
 }
 
 #[contract]
@@ -22,7 +50,7 @@ impl LoanManager {
             .set(&DataKey::NftContract, &nft_contract);
     }
 
-    pub fn request_loan(env: Env, borrower: Address, amount: i128) {
+    pub fn request_loan(env: Env, borrower: Address, amount: i128) -> u32 {
         let nft_contract: Address = env
             .storage()
             .instance()
@@ -43,24 +71,165 @@ impl LoanManager {
             panic!("loan amount must be positive");
         }
 
-        // Loan request logic (placeholder)
+        let loan_id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LoanCount)
+            .unwrap_or(0)
+            + 1;
+
+        let loan = Loan {
+            borrower: borrower.clone(),
+            principal: amount,
+            interest_rate_bps: DEFAULT_INTEREST_RATE_BPS,
+            penalty_rate_bps: DEFAULT_PENALTY_RATE_BPS,
+            start_time: 0,
+            due_time: 0,
+            amount_repaid: 0,
+            status: LoanStatus::Requested,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
+        env.storage().instance().set(&DataKey::LoanCount, &loan_id);
+
         events::loan_requested(&env, borrower, amount);
+        loan_id
     }
 
     pub fn approve_loan(env: Env, loan_id: u32) {
-        // Approval logic (placeholder)
+        let mut loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        if loan.status != LoanStatus::Requested {
+            panic!("loan not in requested state");
+        }
+
+        let now = env.ledger().timestamp();
+        loan.start_time = now;
+        loan.due_time = now + DEFAULT_LOAN_DURATION;
+        loan.status = LoanStatus::Active;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
         events::loan_approved(&env, loan_id);
     }
 
-    pub fn repay(env: Env, borrower: Address, amount: i128) {
+    pub fn repay(env: Env, borrower: Address, loan_id: u32, amount: i128) {
         borrower.require_auth();
 
         if amount <= 0 {
             panic!("repayment amount must be positive");
         }
 
-        // Repayment logic (placeholder)
+        let mut loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        if loan.borrower != borrower {
+            panic!("not the loan borrower");
+        }
+
+        if loan.status != LoanStatus::Active {
+            panic!("loan not active");
+        }
+
+        let now = env.ledger().timestamp();
+        let outstanding = Self::_outstanding_balance(&loan, now);
+
+        if amount > outstanding {
+            panic!("repayment exceeds outstanding balance");
+        }
+
+        loan.amount_repaid += amount;
+
+        let new_outstanding = Self::_outstanding_balance(&loan, now);
+        if new_outstanding <= 0 {
+            loan.status = LoanStatus::Repaid;
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
         events::loan_repaid(&env, borrower, amount);
+    }
+
+    pub fn get_loan(env: Env, loan_id: u32) -> Loan {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found")
+    }
+
+    pub fn get_outstanding_balance(env: Env, loan_id: u32) -> i128 {
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        if loan.status == LoanStatus::Repaid {
+            return 0;
+        }
+
+        let now = env.ledger().timestamp();
+        Self::_outstanding_balance(&loan, now)
+    }
+
+    pub fn get_accrued_interest(env: Env, loan_id: u32) -> i128 {
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        let now = env.ledger().timestamp();
+        if now <= loan.start_time {
+            return 0;
+        }
+
+        repayment::calculate_interest(
+            loan.principal,
+            loan.interest_rate_bps,
+            now - loan.start_time,
+        )
+    }
+
+    pub fn get_penalty(env: Env, loan_id: u32) -> i128 {
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        let now = env.ledger().timestamp();
+        repayment::calculate_penalty(loan.principal, loan.penalty_rate_bps, loan.due_time, now)
+    }
+
+    fn _outstanding_balance(loan: &Loan, current_time: u64) -> i128 {
+        let elapsed = current_time.saturating_sub(loan.start_time);
+        let interest =
+            repayment::calculate_interest(loan.principal, loan.interest_rate_bps, elapsed);
+        let penalty = repayment::calculate_penalty(
+            loan.principal,
+            loan.penalty_rate_bps,
+            loan.due_time,
+            current_time,
+        );
+        let total_owed = loan.principal + interest + penalty;
+        let balance = total_owed - loan.amount_repaid;
+        if balance < 0 {
+            0
+        } else {
+            balance
+        }
     }
 }
 

--- a/contracts/loan_manager/src/repayment.rs
+++ b/contracts/loan_manager/src/repayment.rs
@@ -1,0 +1,46 @@
+const SECONDS_PER_YEAR: i128 = 31_536_000;
+const BPS_DENOMINATOR: i128 = 10_000;
+
+pub fn calculate_interest(principal: i128, rate_bps: u32, elapsed_seconds: u64) -> i128 {
+    if principal <= 0 || rate_bps == 0 || elapsed_seconds == 0 {
+        return 0;
+    }
+
+    let rate = rate_bps as i128;
+    let time = elapsed_seconds as i128;
+
+    principal * rate * time / (BPS_DENOMINATOR * SECONDS_PER_YEAR)
+}
+
+pub fn calculate_outstanding_balance(
+    principal: i128,
+    rate_bps: u32,
+    start_time: u64,
+    current_time: u64,
+    amount_repaid: i128,
+) -> i128 {
+    let elapsed = current_time.saturating_sub(start_time);
+
+    let interest = calculate_interest(principal, rate_bps, elapsed);
+    let balance = principal + interest - amount_repaid;
+
+    if balance < 0 {
+        0
+    } else {
+        balance
+    }
+}
+
+pub fn calculate_penalty(
+    principal: i128,
+    penalty_rate_bps: u32,
+    due_time: u64,
+    current_time: u64,
+) -> i128 {
+    if current_time <= due_time || penalty_rate_bps == 0 {
+        return 0;
+    }
+
+    let overdue_seconds = current_time - due_time;
+    calculate_interest(principal, penalty_rate_bps, overdue_seconds)
+}

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -1,5 +1,9 @@
-use crate::{LoanManager, LoanManagerClient};
-use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env};
+use crate::{LoanManager, LoanManagerClient, LoanStatus};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
 
 #[contract]
 pub struct MockNftContract;
@@ -15,8 +19,11 @@ impl MockNftContract {
     }
 }
 
-#[test]
-fn test_loan_request_success() {
+fn setup_env() -> (
+    Env,
+    LoanManagerClient<'static>,
+    MockNftContractClient<'static>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -27,38 +34,427 @@ fn test_loan_request_success() {
     let nft_client = MockNftContractClient::new(&env, &nft_contract);
     manager.initialize(&nft_contract);
 
-    let borrower = Address::generate(&env);
+    (env, manager, nft_client)
+}
+
+// ── Loan Request Tests ──
+
+#[test]
+fn test_loan_request_success() {
+    let (_env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&_env);
     nft_client.set_score(&borrower, &100);
 
-    // Should succeed without panicking
-    manager.request_loan(&borrower, &1000);
+    let loan_id = manager.request_loan(&borrower, &1000);
+    assert_eq!(loan_id, 1);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.principal, 1000);
+    assert_eq!(loan.status, LoanStatus::Requested);
+}
+
+#[test]
+fn test_sequential_loan_ids() {
+    let (_env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&_env);
+    nft_client.set_score(&borrower, &100);
+
+    let id1 = manager.request_loan(&borrower, &1000);
+    let id2 = manager.request_loan(&borrower, &2000);
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
 }
 
 #[test]
 #[should_panic(expected = "borrower score below threshold")]
 fn test_loan_request_rejected_low_score() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (_env, manager, nft_client) = setup_env();
 
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
-
-    let nft_contract = env.register(MockNftContract, ());
-    let nft_client = MockNftContractClient::new(&env, &nft_contract);
-    manager.initialize(&nft_contract);
-
-    let borrower = Address::generate(&env);
+    let borrower = Address::generate(&_env);
     nft_client.set_score(&borrower, &40);
 
-    // Should panic due to low score
     manager.request_loan(&borrower, &1000);
 }
 
 #[test]
 #[should_panic(expected = "loan amount must be positive")]
 fn test_loan_request_negative_amount() {
+    let (_env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&_env);
+    nft_client.set_score(&borrower, &100);
+
+    manager.request_loan(&borrower, &-100);
+}
+
+// ── Loan Approval Tests ──
+
+#[test]
+fn test_approve_loan() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Active);
+    assert_eq!(loan.start_time, start_ts);
+    assert_eq!(loan.due_time, start_ts + 31_536_000);
+}
+
+#[test]
+#[should_panic(expected = "loan not in requested state")]
+fn test_approve_already_active_loan() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+    manager.approve_loan(&loan_id);
+}
+
+// ── Interest Calculation Tests ──
+
+#[test]
+fn test_interest_accrual_over_time() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 6 months (half a year)
+    let six_months: u64 = 31_536_000 / 2;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + six_months;
+    });
+
+    // 10% annual on 100,000 for half a year = 5,000
+    let interest = manager.get_accrued_interest(&loan_id);
+    assert_eq!(interest, 5000);
+}
+
+#[test]
+fn test_interest_full_year() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1 full year
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000;
+    });
+
+    // 10% annual on 100,000 = 10,000
+    let interest = manager.get_accrued_interest(&loan_id);
+    assert_eq!(interest, 10_000);
+}
+
+#[test]
+fn test_no_interest_before_activation() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+
+    let interest = manager.get_accrued_interest(&loan_id);
+    assert_eq!(interest, 0);
+}
+
+// ── Outstanding Balance Tests ──
+
+#[test]
+fn test_outstanding_balance_at_start() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 100_000);
+}
+
+#[test]
+fn test_outstanding_balance_with_interest() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1 year
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000;
+    });
+
+    // principal(100,000) + interest(10,000) = 110,000
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 110_000);
+}
+
+// ── Penalty Tests ──
+
+#[test]
+fn test_no_penalty_before_due() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 6 months (still before due date)
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000 / 2;
+    });
+
+    let penalty = manager.get_penalty(&loan_id);
+    assert_eq!(penalty, 0);
+}
+
+#[test]
+fn test_penalty_after_due() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1.5 years (6 months past due)
+    let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + one_and_half_years;
+    });
+
+    // 5% penalty on 100,000 for 6 months = 2,500
+    let penalty = manager.get_penalty(&loan_id);
+    assert_eq!(penalty, 2500);
+}
+
+#[test]
+fn test_outstanding_balance_includes_penalty() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1.5 years (6 months overdue)
+    let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + one_and_half_years;
+    });
+
+    // principal(100,000) + interest(15,000 for 1.5yr) + penalty(2,500 for 0.5yr overdue) = 117,500
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 117_500);
+}
+
+// ── Repayment Tests ──
+
+#[test]
+fn test_partial_repayment() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 6 months
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000 / 2;
+    });
+
+    // Outstanding = 100,000 + 5,000 interest = 105,000
+    manager.repay(&borrower, &loan_id, &50_000);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.amount_repaid, 50_000);
+    assert_eq!(loan.status, LoanStatus::Active);
+
+    // Outstanding = 100,000 + 5,000 - 50,000 = 55,000
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 55_000);
+}
+
+#[test]
+fn test_full_repayment_marks_loan_repaid() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1 full year (at due date)
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000;
+    });
+
+    // Outstanding = 100,000 + 10,000 interest = 110,000
+    manager.repay(&borrower, &loan_id, &110_000);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Repaid);
+
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 0);
+}
+
+#[test]
+#[should_panic(expected = "repayment amount must be positive")]
+fn test_repayment_negative_amount() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    manager.repay(&borrower, &loan_id, &-100);
+}
+
+#[test]
+#[should_panic(expected = "repayment exceeds outstanding balance")]
+fn test_repayment_exceeds_balance() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+
+    // At activation time, outstanding is exactly 10,000
+    manager.repay(&borrower, &loan_id, &20_000);
+}
+
+#[test]
+#[should_panic(expected = "not the loan borrower")]
+fn test_repayment_wrong_borrower() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    let other = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+
+    manager.repay(&other, &loan_id, &5_000);
+}
+
+#[test]
+#[should_panic(expected = "loan not active")]
+fn test_repayment_on_requested_loan() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+
+    manager.repay(&borrower, &loan_id, &5_000);
+}
+
+#[test]
+#[should_panic]
+fn test_repayment_unauthorized() {
     let env = Env::default();
-    env.mock_all_auths();
 
     let loan_manager_id = env.register(LoanManager, ());
     let manager = LoanManagerClient::new(&env, &loan_manager_id);
@@ -70,71 +466,123 @@ fn test_loan_request_negative_amount() {
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
 
-    // Should panic due to negative amount
-    manager.request_loan(&borrower, &-100);
-}
-
-#[test]
-fn test_approve_loan_flow() {
-    let env = Env::default();
-
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
-
-    // Currently approve_loan is a placeholder logic doing nothing
-    // Verify it accepts requests cleanly.
-    manager.approve_loan(&1);
-}
-
-#[test]
-fn test_repayment_flow() {
-    let env = Env::default();
     env.mock_all_auths();
+    let loan_id = manager.request_loan(&borrower, &10_000);
 
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+    manager.approve_loan(&loan_id);
 
-    let nft_contract = Address::generate(&env);
-    manager.initialize(&nft_contract);
+    env.mock_auths(&[]);
+    manager.repay(&borrower, &loan_id, &5_000);
+}
+
+// ── Repayment with Penalty Tests ──
+
+#[test]
+fn test_repayment_with_penalty_full_payoff() {
+    let (env, manager, nft_client) = setup_env();
 
     let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
 
-    // Should succeed without panicking
-    manager.repay(&borrower, &500);
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1.5 years (6 months overdue)
+    let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + one_and_half_years;
+    });
+
+    // Total = principal(100,000) + interest(15,000) + penalty(2,500) = 117,500
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 117_500);
+
+    manager.repay(&borrower, &loan_id, &117_500);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Repaid);
+}
+
+// ── Pure Math Function Tests ──
+
+#[test]
+fn test_calculate_interest_zero_principal() {
+    let interest = crate::repayment::calculate_interest(0, 1000, 31_536_000);
+    assert_eq!(interest, 0);
 }
 
 #[test]
-#[should_panic(expected = "repayment amount must be positive")]
-fn test_repayment_negative_amount() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
-
-    let nft_contract = Address::generate(&env);
-    manager.initialize(&nft_contract);
-
-    let borrower = Address::generate(&env);
-
-    // Should panic due to negative amount
-    manager.repay(&borrower, &-100);
+fn test_calculate_interest_zero_rate() {
+    let interest = crate::repayment::calculate_interest(100_000, 0, 31_536_000);
+    assert_eq!(interest, 0);
 }
 
 #[test]
-#[should_panic]
-fn test_access_controls_unauthorized_repay() {
-    let env = Env::default();
-    // NOT using mock_all_auths() to enforce actual signatures
+fn test_calculate_interest_zero_time() {
+    let interest = crate::repayment::calculate_interest(100_000, 1000, 0);
+    assert_eq!(interest, 0);
+}
 
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
+#[test]
+fn test_calculate_interest_one_year() {
+    // 10% on 100,000 for 1 year = 10,000
+    let interest = crate::repayment::calculate_interest(100_000, 1000, 31_536_000);
+    assert_eq!(interest, 10_000);
+}
 
-    let nft_contract = Address::generate(&env);
-    manager.initialize(&nft_contract);
+#[test]
+fn test_calculate_interest_quarter_year() {
+    // 10% on 100,000 for 3 months = 2,500
+    let interest = crate::repayment::calculate_interest(100_000, 1000, 31_536_000 / 4);
+    assert_eq!(interest, 2_500);
+}
 
-    let borrower = Address::generate(&env);
+#[test]
+fn test_calculate_outstanding_balance_no_repayment() {
+    let balance = crate::repayment::calculate_outstanding_balance(100_000, 1000, 0, 31_536_000, 0);
+    // 100,000 + 10,000 interest = 110,000
+    assert_eq!(balance, 110_000);
+}
 
-    // Attempting to repay without proper Authorization scope should panic natively.
-    manager.repay(&borrower, &500);
+#[test]
+fn test_calculate_outstanding_balance_with_repayment() {
+    let balance =
+        crate::repayment::calculate_outstanding_balance(100_000, 1000, 0, 31_536_000, 60_000);
+    // 100,000 + 10,000 - 60,000 = 50,000
+    assert_eq!(balance, 50_000);
+}
+
+#[test]
+fn test_calculate_outstanding_balance_overpaid_returns_zero() {
+    let balance =
+        crate::repayment::calculate_outstanding_balance(100_000, 1000, 0, 31_536_000, 200_000);
+    assert_eq!(balance, 0);
+}
+
+#[test]
+fn test_calculate_penalty_before_due() {
+    let penalty = crate::repayment::calculate_penalty(100_000, 500, 31_536_000, 0);
+    assert_eq!(penalty, 0);
+}
+
+#[test]
+fn test_calculate_penalty_at_due() {
+    let penalty = crate::repayment::calculate_penalty(100_000, 500, 31_536_000, 31_536_000);
+    assert_eq!(penalty, 0);
+}
+
+#[test]
+fn test_calculate_penalty_one_year_overdue() {
+    // 5% on 100,000 for 1 year overdue = 5,000
+    let penalty = crate::repayment::calculate_penalty(100_000, 500, 0, 31_536_000);
+    assert_eq!(penalty, 5_000);
 }


### PR DESCRIPTION
## Summary

- Adds a `repayment` module with fixed-point arithmetic functions for **interest calculation** (simple interest via basis points), **outstanding balance** (principal + interest + penalty - repaid), and **penalty fee** accrual on overdue loans
- Introduces `Loan` struct and `LoanStatus` enum with persistent storage, converting `loan_manager` from placeholder logic to a functional loan lifecycle (request → approve → repay)
- Adds contract query functions: `get_loan`, `get_outstanding_balance`, `get_accrued_interest`, `get_penalty`

Closes #3

## Implementation details

- **Interest**: Simple interest using basis points (1 bps = 0.01%). Default: 1000 bps (10% annual)
- **Penalty**: Additional interest applied on overdue principal. Default: 500 bps (5% annual)
- **Arithmetic**: All calculations use `i128` integer math — no floating point. Time measured in seconds from ledger timestamps
- **Loan duration**: Default 1 year (31,536,000 seconds)

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -p loan_manager` — no warnings
- [x] `cargo test` — all 49 tests pass (33 loan_manager + 6 lending_pool + 10 remittance_nft)
- [x] Interest: zero principal/rate/time, quarter-year, half-year, full-year
- [x] Outstanding balance: at start, with interest, with penalty, after partial repayment
- [x] Penalty: before due (0), after due, included in outstanding balance
- [x] Repayment: partial, full payoff marks Repaid, overpayment rejected, wrong borrower rejected, unauthorized rejected
- [x] Loan lifecycle: sequential IDs, approval sets timestamps, double-approve rejected