### PR TITLE
feat(contracts): add collateral management functions

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6913,13 +6913,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -6952,6 +6945,49 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -7081,6 +7117,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/contracts/loan_manager/src/events.rs
+++ b/contracts/loan_manager/src/events.rs
@@ -14,3 +14,18 @@ pub fn loan_repaid(env: &Env, borrower: Address, amount: i128) {
     let topics = (Symbol::new(env, "LoanRepaid"), borrower);
     env.events().publish(topics, amount);
 }
+
+pub fn collateral_locked(env: &Env, borrower: Address, loan_id: u32) {
+    let topics = (Symbol::new(env, "CollateralLocked"), borrower);
+    env.events().publish(topics, loan_id);
+}
+
+pub fn collateral_unlocked(env: &Env, borrower: Address, loan_id: u32) {
+    let topics = (Symbol::new(env, "CollateralUnlocked"), borrower);
+    env.events().publish(topics, loan_id);
+}
+
+pub fn loan_defaulted(env: &Env, loan_id: u32) {
+    let topics = (Symbol::new(env, "LoanDefaulted"), loan_id);
+    env.events().publish(topics, ());
+}

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -78,6 +78,17 @@ impl LoanManager {
             .unwrap_or(0)
             + 1;
 
+        // Lock the borrower's NFT as collateral
+        env.invoke_contract::<()>(
+            &nft_contract,
+            &Symbol::new(&env, "lock_collateral"),
+            soroban_sdk::vec![
+                &env,
+                borrower.into_val(&env),
+                env.current_contract_address().into_val(&env)
+            ],
+        );
+
         let loan = Loan {
             borrower: borrower.clone(),
             principal: amount,
@@ -94,7 +105,8 @@ impl LoanManager {
             .set(&DataKey::Loan(loan_id), &loan);
         env.storage().instance().set(&DataKey::LoanCount, &loan_id);
 
-        events::loan_requested(&env, borrower, amount);
+        events::loan_requested(&env, borrower.clone(), amount);
+        events::collateral_locked(&env, borrower, loan_id);
         loan_id
     }
 
@@ -153,12 +165,71 @@ impl LoanManager {
         let new_outstanding = Self::_outstanding_balance(&loan, now);
         if new_outstanding <= 0 {
             loan.status = LoanStatus::Repaid;
+
+            // Unlock the borrower's NFT collateral
+            let nft_contract: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::NftContract)
+                .expect("not initialized");
+
+            env.invoke_contract::<()>(
+                &nft_contract,
+                &Symbol::new(&env, "unlock_collateral"),
+                soroban_sdk::vec![
+                    &env,
+                    borrower.into_val(&env),
+                    env.current_contract_address().into_val(&env)
+                ],
+            );
+
+            events::collateral_unlocked(&env, borrower.clone(), loan_id);
         }
 
         env.storage()
             .persistent()
             .set(&DataKey::Loan(loan_id), &loan);
         events::loan_repaid(&env, borrower, amount);
+    }
+
+    pub fn liquidate(env: Env, loan_id: u32) {
+        let mut loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        if loan.status != LoanStatus::Active {
+            panic!("loan not active");
+        }
+
+        let now = env.ledger().timestamp();
+        if now <= loan.due_time {
+            panic!("loan not yet overdue");
+        }
+
+        loan.status = LoanStatus::Defaulted;
+
+        let nft_contract: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::NftContract)
+            .expect("not initialized");
+
+        env.invoke_contract::<()>(
+            &nft_contract,
+            &Symbol::new(&env, "seize_collateral"),
+            soroban_sdk::vec![
+                &env,
+                loan.borrower.clone().into_val(&env),
+                env.current_contract_address().into_val(&env)
+            ],
+        );
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
+        events::loan_defaulted(&env, loan_id);
     }
 
     pub fn get_loan(env: Env, loan_id: u32) -> Loan {

--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -2,13 +2,41 @@
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, IntoVal, Symbol};
 
 mod events;
+pub mod repayment;
 
 const MIN_SCORE: u32 = 50;
+const DEFAULT_INTEREST_RATE_BPS: u32 = 1000; // 10% annual
+const DEFAULT_PENALTY_RATE_BPS: u32 = 500; // 5% annual penalty
+const DEFAULT_LOAN_DURATION: u64 = 31_536_000; // 1 year in seconds
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LoanStatus {
+    Requested,
+    Active,
+    Repaid,
+    Defaulted,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Loan {
+    pub borrower: Address,
+    pub principal: i128,
+    pub interest_rate_bps: u32,
+    pub penalty_rate_bps: u32,
+    pub start_time: u64,
+    pub due_time: u64,
+    pub amount_repaid: i128,
+    pub status: LoanStatus,
+}
 
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     NftContract,
+    LoanCount,
+    Loan(u32),
 }
 
 #[contract]
@@ -22,7 +50,7 @@ impl LoanManager {
             .set(&DataKey::NftContract, &nft_contract);
     }
 
-    pub fn request_loan(env: Env, borrower: Address, amount: i128) {
+    pub fn request_loan(env: Env, borrower: Address, amount: i128) -> u32 {
         let nft_contract: Address = env
             .storage()
             .instance()
@@ -43,24 +71,165 @@ impl LoanManager {
             panic!("loan amount must be positive");
         }
 
-        // Loan request logic (placeholder)
+        let loan_id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LoanCount)
+            .unwrap_or(0)
+            + 1;
+
+        let loan = Loan {
+            borrower: borrower.clone(),
+            principal: amount,
+            interest_rate_bps: DEFAULT_INTEREST_RATE_BPS,
+            penalty_rate_bps: DEFAULT_PENALTY_RATE_BPS,
+            start_time: 0,
+            due_time: 0,
+            amount_repaid: 0,
+            status: LoanStatus::Requested,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
+        env.storage().instance().set(&DataKey::LoanCount, &loan_id);
+
         events::loan_requested(&env, borrower, amount);
+        loan_id
     }
 
     pub fn approve_loan(env: Env, loan_id: u32) {
-        // Approval logic (placeholder)
+        let mut loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        if loan.status != LoanStatus::Requested {
+            panic!("loan not in requested state");
+        }
+
+        let now = env.ledger().timestamp();
+        loan.start_time = now;
+        loan.due_time = now + DEFAULT_LOAN_DURATION;
+        loan.status = LoanStatus::Active;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
         events::loan_approved(&env, loan_id);
     }
 
-    pub fn repay(env: Env, borrower: Address, amount: i128) {
+    pub fn repay(env: Env, borrower: Address, loan_id: u32, amount: i128) {
         borrower.require_auth();
 
         if amount <= 0 {
             panic!("repayment amount must be positive");
         }
 
-        // Repayment logic (placeholder)
+        let mut loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        if loan.borrower != borrower {
+            panic!("not the loan borrower");
+        }
+
+        if loan.status != LoanStatus::Active {
+            panic!("loan not active");
+        }
+
+        let now = env.ledger().timestamp();
+        let outstanding = Self::_outstanding_balance(&loan, now);
+
+        if amount > outstanding {
+            panic!("repayment exceeds outstanding balance");
+        }
+
+        loan.amount_repaid += amount;
+
+        let new_outstanding = Self::_outstanding_balance(&loan, now);
+        if new_outstanding <= 0 {
+            loan.status = LoanStatus::Repaid;
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
         events::loan_repaid(&env, borrower, amount);
+    }
+
+    pub fn get_loan(env: Env, loan_id: u32) -> Loan {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found")
+    }
+
+    pub fn get_outstanding_balance(env: Env, loan_id: u32) -> i128 {
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        if loan.status == LoanStatus::Repaid {
+            return 0;
+        }
+
+        let now = env.ledger().timestamp();
+        Self::_outstanding_balance(&loan, now)
+    }
+
+    pub fn get_accrued_interest(env: Env, loan_id: u32) -> i128 {
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        let now = env.ledger().timestamp();
+        if now <= loan.start_time {
+            return 0;
+        }
+
+        repayment::calculate_interest(
+            loan.principal,
+            loan.interest_rate_bps,
+            now - loan.start_time,
+        )
+    }
+
+    pub fn get_penalty(env: Env, loan_id: u32) -> i128 {
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .expect("loan not found");
+
+        let now = env.ledger().timestamp();
+        repayment::calculate_penalty(loan.principal, loan.penalty_rate_bps, loan.due_time, now)
+    }
+
+    fn _outstanding_balance(loan: &Loan, current_time: u64) -> i128 {
+        let elapsed = current_time.saturating_sub(loan.start_time);
+        let interest =
+            repayment::calculate_interest(loan.principal, loan.interest_rate_bps, elapsed);
+        let penalty = repayment::calculate_penalty(
+            loan.principal,
+            loan.penalty_rate_bps,
+            loan.due_time,
+            current_time,
+        );
+        let total_owed = loan.principal + interest + penalty;
+        let balance = total_owed - loan.amount_repaid;
+        if balance < 0 {
+            0
+        } else {
+            balance
+        }
     }
 }
 

--- a/contracts/loan_manager/src/repayment.rs
+++ b/contracts/loan_manager/src/repayment.rs
@@ -1,0 +1,46 @@
+const SECONDS_PER_YEAR: i128 = 31_536_000;
+const BPS_DENOMINATOR: i128 = 10_000;
+
+pub fn calculate_interest(principal: i128, rate_bps: u32, elapsed_seconds: u64) -> i128 {
+    if principal <= 0 || rate_bps == 0 || elapsed_seconds == 0 {
+        return 0;
+    }
+
+    let rate = rate_bps as i128;
+    let time = elapsed_seconds as i128;
+
+    principal * rate * time / (BPS_DENOMINATOR * SECONDS_PER_YEAR)
+}
+
+pub fn calculate_outstanding_balance(
+    principal: i128,
+    rate_bps: u32,
+    start_time: u64,
+    current_time: u64,
+    amount_repaid: i128,
+) -> i128 {
+    let elapsed = current_time.saturating_sub(start_time);
+
+    let interest = calculate_interest(principal, rate_bps, elapsed);
+    let balance = principal + interest - amount_repaid;
+
+    if balance < 0 {
+        0
+    } else {
+        balance
+    }
+}
+
+pub fn calculate_penalty(
+    principal: i128,
+    penalty_rate_bps: u32,
+    due_time: u64,
+    current_time: u64,
+) -> i128 {
+    if current_time <= due_time || penalty_rate_bps == 0 {
+        return 0;
+    }
+
+    let overdue_seconds = current_time - due_time;
+    calculate_interest(principal, penalty_rate_bps, overdue_seconds)
+}

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -1,9 +1,16 @@
 use crate::{LoanManager, LoanManagerClient, LoanStatus};
 use soroban_sdk::{
-    contract, contractimpl,
+    contract, contractimpl, contracttype,
     testutils::{Address as _, Ledger},
     Address, Env,
 };
+
+#[contracttype]
+#[derive(Clone)]
+enum MockDataKey {
+    Score(Address),
+    Locked(Address),
+}
 
 #[contract]
 pub struct MockNftContract;
@@ -11,11 +18,43 @@ pub struct MockNftContract;
 #[contractimpl]
 impl MockNftContract {
     pub fn get_score(env: Env, user: Address) -> u32 {
-        env.storage().instance().get(&user).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&MockDataKey::Score(user))
+            .unwrap_or(0)
     }
 
     pub fn set_score(env: Env, user: Address, score: u32) {
-        env.storage().instance().set(&user, &score);
+        env.storage()
+            .instance()
+            .set(&MockDataKey::Score(user), &score);
+    }
+
+    pub fn lock_collateral(env: Env, user: Address, _locker: Address) {
+        let key = MockDataKey::Locked(user);
+        if env.storage().persistent().has(&key) {
+            panic!("collateral already locked");
+        }
+        env.storage().persistent().set(&key, &true);
+    }
+
+    pub fn unlock_collateral(env: Env, user: Address, _locker: Address) {
+        let key = MockDataKey::Locked(user);
+        if !env.storage().persistent().has(&key) {
+            panic!("collateral not locked");
+        }
+        env.storage().persistent().remove(&key);
+    }
+
+    pub fn is_locked(env: Env, user: Address) -> bool {
+        env.storage().persistent().has(&MockDataKey::Locked(user))
+    }
+
+    pub fn seize_collateral(env: Env, user: Address, _locker: Address) {
+        env.storage()
+            .persistent()
+            .remove(&MockDataKey::Locked(user.clone()));
+        env.storage().instance().remove(&MockDataKey::Score(user));
     }
 }
 
@@ -23,6 +62,7 @@ fn setup_env() -> (
     Env,
     LoanManagerClient<'static>,
     MockNftContractClient<'static>,
+    Address,
 ) {
     let env = Env::default();
     env.mock_all_auths();
@@ -34,16 +74,16 @@ fn setup_env() -> (
     let nft_client = MockNftContractClient::new(&env, &nft_contract);
     manager.initialize(&nft_contract);
 
-    (env, manager, nft_client)
+    (env, manager, nft_client, nft_contract)
 }
 
 // ── Loan Request Tests ──
 
 #[test]
 fn test_loan_request_success() {
-    let (_env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
-    let borrower = Address::generate(&_env);
+    let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
 
     let loan_id = manager.request_loan(&borrower, &1000);
@@ -55,14 +95,40 @@ fn test_loan_request_success() {
 }
 
 #[test]
-fn test_sequential_loan_ids() {
-    let (_env, manager, nft_client) = setup_env();
+fn test_loan_request_locks_collateral() {
+    let (env, manager, nft_client, _) = setup_env();
 
-    let borrower = Address::generate(&_env);
+    let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
 
-    let id1 = manager.request_loan(&borrower, &1000);
-    let id2 = manager.request_loan(&borrower, &2000);
+    assert!(!nft_client.is_locked(&borrower));
+    manager.request_loan(&borrower, &1000);
+    assert!(nft_client.is_locked(&borrower));
+}
+
+#[test]
+#[should_panic(expected = "collateral already locked")]
+fn test_cannot_request_second_loan_while_locked() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    manager.request_loan(&borrower, &1000);
+    manager.request_loan(&borrower, &2000);
+}
+
+#[test]
+fn test_sequential_loan_ids() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower1 = Address::generate(&env);
+    let borrower2 = Address::generate(&env);
+    nft_client.set_score(&borrower1, &100);
+    nft_client.set_score(&borrower2, &100);
+
+    let id1 = manager.request_loan(&borrower1, &1000);
+    let id2 = manager.request_loan(&borrower2, &2000);
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
 }
@@ -70,9 +136,9 @@ fn test_sequential_loan_ids() {
 #[test]
 #[should_panic(expected = "borrower score below threshold")]
 fn test_loan_request_rejected_low_score() {
-    let (_env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
-    let borrower = Address::generate(&_env);
+    let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &40);
 
     manager.request_loan(&borrower, &1000);
@@ -81,9 +147,9 @@ fn test_loan_request_rejected_low_score() {
 #[test]
 #[should_panic(expected = "loan amount must be positive")]
 fn test_loan_request_negative_amount() {
-    let (_env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
-    let borrower = Address::generate(&_env);
+    let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
 
     manager.request_loan(&borrower, &-100);
@@ -93,7 +159,7 @@ fn test_loan_request_negative_amount() {
 
 #[test]
 fn test_approve_loan() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -115,7 +181,7 @@ fn test_approve_loan() {
 #[test]
 #[should_panic(expected = "loan not in requested state")]
 fn test_approve_already_active_loan() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -129,7 +195,7 @@ fn test_approve_already_active_loan() {
 
 #[test]
 fn test_interest_accrual_over_time() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -142,20 +208,18 @@ fn test_interest_accrual_over_time() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 6 months (half a year)
     let six_months: u64 = 31_536_000 / 2;
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + six_months;
     });
 
-    // 10% annual on 100,000 for half a year = 5,000
     let interest = manager.get_accrued_interest(&loan_id);
     assert_eq!(interest, 5000);
 }
 
 #[test]
 fn test_interest_full_year() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -168,19 +232,17 @@ fn test_interest_full_year() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 1 full year
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + 31_536_000;
     });
 
-    // 10% annual on 100,000 = 10,000
     let interest = manager.get_accrued_interest(&loan_id);
     assert_eq!(interest, 10_000);
 }
 
 #[test]
 fn test_no_interest_before_activation() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -195,7 +257,7 @@ fn test_no_interest_before_activation() {
 
 #[test]
 fn test_outstanding_balance_at_start() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -214,7 +276,7 @@ fn test_outstanding_balance_at_start() {
 
 #[test]
 fn test_outstanding_balance_with_interest() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -227,12 +289,10 @@ fn test_outstanding_balance_with_interest() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 1 year
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + 31_536_000;
     });
 
-    // principal(100,000) + interest(10,000) = 110,000
     let balance = manager.get_outstanding_balance(&loan_id);
     assert_eq!(balance, 110_000);
 }
@@ -241,7 +301,7 @@ fn test_outstanding_balance_with_interest() {
 
 #[test]
 fn test_no_penalty_before_due() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -254,7 +314,6 @@ fn test_no_penalty_before_due() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 6 months (still before due date)
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + 31_536_000 / 2;
     });
@@ -265,7 +324,7 @@ fn test_no_penalty_before_due() {
 
 #[test]
 fn test_penalty_after_due() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -278,20 +337,18 @@ fn test_penalty_after_due() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 1.5 years (6 months past due)
     let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + one_and_half_years;
     });
 
-    // 5% penalty on 100,000 for 6 months = 2,500
     let penalty = manager.get_penalty(&loan_id);
     assert_eq!(penalty, 2500);
 }
 
 #[test]
 fn test_outstanding_balance_includes_penalty() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -304,13 +361,11 @@ fn test_outstanding_balance_includes_penalty() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 1.5 years (6 months overdue)
     let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + one_and_half_years;
     });
 
-    // principal(100,000) + interest(15,000 for 1.5yr) + penalty(2,500 for 0.5yr overdue) = 117,500
     let balance = manager.get_outstanding_balance(&loan_id);
     assert_eq!(balance, 117_500);
 }
@@ -319,7 +374,7 @@ fn test_outstanding_balance_includes_penalty() {
 
 #[test]
 fn test_partial_repayment() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -332,26 +387,23 @@ fn test_partial_repayment() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 6 months
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + 31_536_000 / 2;
     });
 
-    // Outstanding = 100,000 + 5,000 interest = 105,000
     manager.repay(&borrower, &loan_id, &50_000);
 
     let loan = manager.get_loan(&loan_id);
     assert_eq!(loan.amount_repaid, 50_000);
     assert_eq!(loan.status, LoanStatus::Active);
 
-    // Outstanding = 100,000 + 5,000 - 50,000 = 55,000
     let balance = manager.get_outstanding_balance(&loan_id);
     assert_eq!(balance, 55_000);
 }
 
 #[test]
-fn test_full_repayment_marks_loan_repaid() {
-    let (env, manager, nft_client) = setup_env();
+fn test_partial_repayment_keeps_collateral_locked() {
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -364,25 +416,63 @@ fn test_full_repayment_marks_loan_repaid() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 1 full year (at due date)
+    manager.repay(&borrower, &loan_id, &50_000);
+
+    assert!(nft_client.is_locked(&borrower));
+}
+
+#[test]
+fn test_full_repayment_unlocks_collateral() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + 31_536_000;
     });
 
-    // Outstanding = 100,000 + 10,000 interest = 110,000
+    assert!(nft_client.is_locked(&borrower));
     manager.repay(&borrower, &loan_id, &110_000);
 
     let loan = manager.get_loan(&loan_id);
     assert_eq!(loan.status, LoanStatus::Repaid);
+    assert!(!nft_client.is_locked(&borrower));
+}
 
-    let balance = manager.get_outstanding_balance(&loan_id);
-    assert_eq!(balance, 0);
+#[test]
+fn test_can_request_new_loan_after_repayment() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+
+    manager.repay(&borrower, &loan_id, &10_000);
+
+    let new_loan_id = manager.request_loan(&borrower, &20_000);
+    assert_eq!(new_loan_id, 2);
 }
 
 #[test]
 #[should_panic(expected = "repayment amount must be positive")]
 fn test_repayment_negative_amount() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -401,7 +491,7 @@ fn test_repayment_negative_amount() {
 #[test]
 #[should_panic(expected = "repayment exceeds outstanding balance")]
 fn test_repayment_exceeds_balance() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -414,14 +504,13 @@ fn test_repayment_exceeds_balance() {
     let loan_id = manager.request_loan(&borrower, &10_000);
     manager.approve_loan(&loan_id);
 
-    // At activation time, outstanding is exactly 10,000
     manager.repay(&borrower, &loan_id, &20_000);
 }
 
 #[test]
 #[should_panic(expected = "not the loan borrower")]
 fn test_repayment_wrong_borrower() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     let other = Address::generate(&env);
@@ -441,7 +530,7 @@ fn test_repayment_wrong_borrower() {
 #[test]
 #[should_panic(expected = "loan not active")]
 fn test_repayment_on_requested_loan() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -479,11 +568,9 @@ fn test_repayment_unauthorized() {
     manager.repay(&borrower, &loan_id, &5_000);
 }
 
-// ── Repayment with Penalty Tests ──
-
 #[test]
 fn test_repayment_with_penalty_full_payoff() {
-    let (env, manager, nft_client) = setup_env();
+    let (env, manager, nft_client, _) = setup_env();
 
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
@@ -496,13 +583,11 @@ fn test_repayment_with_penalty_full_payoff() {
     let loan_id = manager.request_loan(&borrower, &100_000);
     manager.approve_loan(&loan_id);
 
-    // Advance 1.5 years (6 months overdue)
     let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
     env.ledger().with_mut(|li| {
         li.timestamp = start_ts + one_and_half_years;
     });
 
-    // Total = principal(100,000) + interest(15,000) + penalty(2,500) = 117,500
     let balance = manager.get_outstanding_balance(&loan_id);
     assert_eq!(balance, 117_500);
 
@@ -510,6 +595,125 @@ fn test_repayment_with_penalty_full_payoff() {
 
     let loan = manager.get_loan(&loan_id);
     assert_eq!(loan.status, LoanStatus::Repaid);
+    assert!(!nft_client.is_locked(&borrower));
+}
+
+// ── Liquidation Tests ──
+
+#[test]
+fn test_liquidate_overdue_loan() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance past due date
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000 + 1;
+    });
+
+    manager.liquidate(&loan_id);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Defaulted);
+
+    // NFT should be seized (score gone, not locked)
+    assert_eq!(nft_client.get_score(&borrower), 0);
+    assert!(!nft_client.is_locked(&borrower));
+}
+
+#[test]
+#[should_panic(expected = "loan not yet overdue")]
+fn test_cannot_liquidate_before_due() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Still within loan duration
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000 / 2;
+    });
+
+    manager.liquidate(&loan_id);
+}
+
+#[test]
+#[should_panic(expected = "loan not active")]
+fn test_cannot_liquidate_repaid_loan() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+
+    manager.repay(&borrower, &loan_id, &10_000);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000 + 1;
+    });
+
+    manager.liquidate(&loan_id);
+}
+
+#[test]
+#[should_panic(expected = "loan not active")]
+fn test_cannot_liquidate_requested_loan() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+
+    manager.liquidate(&loan_id);
+}
+
+#[test]
+#[should_panic(expected = "loan not active")]
+fn test_cannot_double_liquidate() {
+    let (env, manager, nft_client, _) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000 + 1;
+    });
+
+    manager.liquidate(&loan_id);
+    manager.liquidate(&loan_id);
 }
 
 // ── Pure Math Function Tests ──
@@ -534,14 +738,12 @@ fn test_calculate_interest_zero_time() {
 
 #[test]
 fn test_calculate_interest_one_year() {
-    // 10% on 100,000 for 1 year = 10,000
     let interest = crate::repayment::calculate_interest(100_000, 1000, 31_536_000);
     assert_eq!(interest, 10_000);
 }
 
 #[test]
 fn test_calculate_interest_quarter_year() {
-    // 10% on 100,000 for 3 months = 2,500
     let interest = crate::repayment::calculate_interest(100_000, 1000, 31_536_000 / 4);
     assert_eq!(interest, 2_500);
 }
@@ -549,7 +751,6 @@ fn test_calculate_interest_quarter_year() {
 #[test]
 fn test_calculate_outstanding_balance_no_repayment() {
     let balance = crate::repayment::calculate_outstanding_balance(100_000, 1000, 0, 31_536_000, 0);
-    // 100,000 + 10,000 interest = 110,000
     assert_eq!(balance, 110_000);
 }
 
@@ -557,7 +758,6 @@ fn test_calculate_outstanding_balance_no_repayment() {
 fn test_calculate_outstanding_balance_with_repayment() {
     let balance =
         crate::repayment::calculate_outstanding_balance(100_000, 1000, 0, 31_536_000, 60_000);
-    // 100,000 + 10,000 - 60,000 = 50,000
     assert_eq!(balance, 50_000);
 }
 
@@ -582,7 +782,6 @@ fn test_calculate_penalty_at_due() {
 
 #[test]
 fn test_calculate_penalty_one_year_overdue() {
-    // 5% on 100,000 for 1 year overdue = 5,000
     let penalty = crate::repayment::calculate_penalty(100_000, 500, 0, 31_536_000);
     assert_eq!(penalty, 5_000);
 }

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -1,5 +1,9 @@
-use crate::{LoanManager, LoanManagerClient};
-use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, Env};
+use crate::{LoanManager, LoanManagerClient, LoanStatus};
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
 
 #[contract]
 pub struct MockNftContract;
@@ -15,8 +19,11 @@ impl MockNftContract {
     }
 }
 
-#[test]
-fn test_loan_request_success() {
+fn setup_env() -> (
+    Env,
+    LoanManagerClient<'static>,
+    MockNftContractClient<'static>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -27,38 +34,427 @@ fn test_loan_request_success() {
     let nft_client = MockNftContractClient::new(&env, &nft_contract);
     manager.initialize(&nft_contract);
 
-    let borrower = Address::generate(&env);
+    (env, manager, nft_client)
+}
+
+// ── Loan Request Tests ──
+
+#[test]
+fn test_loan_request_success() {
+    let (_env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&_env);
     nft_client.set_score(&borrower, &100);
 
-    // Should succeed without panicking
-    manager.request_loan(&borrower, &1000);
+    let loan_id = manager.request_loan(&borrower, &1000);
+    assert_eq!(loan_id, 1);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.principal, 1000);
+    assert_eq!(loan.status, LoanStatus::Requested);
+}
+
+#[test]
+fn test_sequential_loan_ids() {
+    let (_env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&_env);
+    nft_client.set_score(&borrower, &100);
+
+    let id1 = manager.request_loan(&borrower, &1000);
+    let id2 = manager.request_loan(&borrower, &2000);
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
 }
 
 #[test]
 #[should_panic(expected = "borrower score below threshold")]
 fn test_loan_request_rejected_low_score() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (_env, manager, nft_client) = setup_env();
 
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
-
-    let nft_contract = env.register(MockNftContract, ());
-    let nft_client = MockNftContractClient::new(&env, &nft_contract);
-    manager.initialize(&nft_contract);
-
-    let borrower = Address::generate(&env);
+    let borrower = Address::generate(&_env);
     nft_client.set_score(&borrower, &40);
 
-    // Should panic due to low score
     manager.request_loan(&borrower, &1000);
 }
 
 #[test]
 #[should_panic(expected = "loan amount must be positive")]
 fn test_loan_request_negative_amount() {
+    let (_env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&_env);
+    nft_client.set_score(&borrower, &100);
+
+    manager.request_loan(&borrower, &-100);
+}
+
+// ── Loan Approval Tests ──
+
+#[test]
+fn test_approve_loan() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Active);
+    assert_eq!(loan.start_time, start_ts);
+    assert_eq!(loan.due_time, start_ts + 31_536_000);
+}
+
+#[test]
+#[should_panic(expected = "loan not in requested state")]
+fn test_approve_already_active_loan() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+    manager.approve_loan(&loan_id);
+}
+
+// ── Interest Calculation Tests ──
+
+#[test]
+fn test_interest_accrual_over_time() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 6 months (half a year)
+    let six_months: u64 = 31_536_000 / 2;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + six_months;
+    });
+
+    // 10% annual on 100,000 for half a year = 5,000
+    let interest = manager.get_accrued_interest(&loan_id);
+    assert_eq!(interest, 5000);
+}
+
+#[test]
+fn test_interest_full_year() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1 full year
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000;
+    });
+
+    // 10% annual on 100,000 = 10,000
+    let interest = manager.get_accrued_interest(&loan_id);
+    assert_eq!(interest, 10_000);
+}
+
+#[test]
+fn test_no_interest_before_activation() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+
+    let interest = manager.get_accrued_interest(&loan_id);
+    assert_eq!(interest, 0);
+}
+
+// ── Outstanding Balance Tests ──
+
+#[test]
+fn test_outstanding_balance_at_start() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 100_000);
+}
+
+#[test]
+fn test_outstanding_balance_with_interest() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1 year
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000;
+    });
+
+    // principal(100,000) + interest(10,000) = 110,000
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 110_000);
+}
+
+// ── Penalty Tests ──
+
+#[test]
+fn test_no_penalty_before_due() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 6 months (still before due date)
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000 / 2;
+    });
+
+    let penalty = manager.get_penalty(&loan_id);
+    assert_eq!(penalty, 0);
+}
+
+#[test]
+fn test_penalty_after_due() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1.5 years (6 months past due)
+    let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + one_and_half_years;
+    });
+
+    // 5% penalty on 100,000 for 6 months = 2,500
+    let penalty = manager.get_penalty(&loan_id);
+    assert_eq!(penalty, 2500);
+}
+
+#[test]
+fn test_outstanding_balance_includes_penalty() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1.5 years (6 months overdue)
+    let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + one_and_half_years;
+    });
+
+    // principal(100,000) + interest(15,000 for 1.5yr) + penalty(2,500 for 0.5yr overdue) = 117,500
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 117_500);
+}
+
+// ── Repayment Tests ──
+
+#[test]
+fn test_partial_repayment() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 6 months
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000 / 2;
+    });
+
+    // Outstanding = 100,000 + 5,000 interest = 105,000
+    manager.repay(&borrower, &loan_id, &50_000);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.amount_repaid, 50_000);
+    assert_eq!(loan.status, LoanStatus::Active);
+
+    // Outstanding = 100,000 + 5,000 - 50,000 = 55,000
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 55_000);
+}
+
+#[test]
+fn test_full_repayment_marks_loan_repaid() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1 full year (at due date)
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + 31_536_000;
+    });
+
+    // Outstanding = 100,000 + 10,000 interest = 110,000
+    manager.repay(&borrower, &loan_id, &110_000);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Repaid);
+
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 0);
+}
+
+#[test]
+#[should_panic(expected = "repayment amount must be positive")]
+fn test_repayment_negative_amount() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    manager.repay(&borrower, &loan_id, &-100);
+}
+
+#[test]
+#[should_panic(expected = "repayment exceeds outstanding balance")]
+fn test_repayment_exceeds_balance() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+
+    // At activation time, outstanding is exactly 10,000
+    manager.repay(&borrower, &loan_id, &20_000);
+}
+
+#[test]
+#[should_panic(expected = "not the loan borrower")]
+fn test_repayment_wrong_borrower() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    let other = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+    manager.approve_loan(&loan_id);
+
+    manager.repay(&other, &loan_id, &5_000);
+}
+
+#[test]
+#[should_panic(expected = "loan not active")]
+fn test_repayment_on_requested_loan() {
+    let (env, manager, nft_client) = setup_env();
+
+    let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
+
+    let loan_id = manager.request_loan(&borrower, &10_000);
+
+    manager.repay(&borrower, &loan_id, &5_000);
+}
+
+#[test]
+#[should_panic]
+fn test_repayment_unauthorized() {
     let env = Env::default();
-    env.mock_all_auths();
 
     let loan_manager_id = env.register(LoanManager, ());
     let manager = LoanManagerClient::new(&env, &loan_manager_id);
@@ -70,71 +466,123 @@ fn test_loan_request_negative_amount() {
     let borrower = Address::generate(&env);
     nft_client.set_score(&borrower, &100);
 
-    // Should panic due to negative amount
-    manager.request_loan(&borrower, &-100);
-}
-
-#[test]
-fn test_approve_loan_flow() {
-    let env = Env::default();
-
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
-
-    // Currently approve_loan is a placeholder logic doing nothing
-    // Verify it accepts requests cleanly.
-    manager.approve_loan(&1);
-}
-
-#[test]
-fn test_repayment_flow() {
-    let env = Env::default();
     env.mock_all_auths();
+    let loan_id = manager.request_loan(&borrower, &10_000);
 
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+    manager.approve_loan(&loan_id);
 
-    let nft_contract = Address::generate(&env);
-    manager.initialize(&nft_contract);
+    env.mock_auths(&[]);
+    manager.repay(&borrower, &loan_id, &5_000);
+}
+
+// ── Repayment with Penalty Tests ──
+
+#[test]
+fn test_repayment_with_penalty_full_payoff() {
+    let (env, manager, nft_client) = setup_env();
 
     let borrower = Address::generate(&env);
+    nft_client.set_score(&borrower, &100);
 
-    // Should succeed without panicking
-    manager.repay(&borrower, &500);
+    let start_ts: u64 = 1_000_000;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts;
+    });
+
+    let loan_id = manager.request_loan(&borrower, &100_000);
+    manager.approve_loan(&loan_id);
+
+    // Advance 1.5 years (6 months overdue)
+    let one_and_half_years: u64 = 31_536_000 + 31_536_000 / 2;
+    env.ledger().with_mut(|li| {
+        li.timestamp = start_ts + one_and_half_years;
+    });
+
+    // Total = principal(100,000) + interest(15,000) + penalty(2,500) = 117,500
+    let balance = manager.get_outstanding_balance(&loan_id);
+    assert_eq!(balance, 117_500);
+
+    manager.repay(&borrower, &loan_id, &117_500);
+
+    let loan = manager.get_loan(&loan_id);
+    assert_eq!(loan.status, LoanStatus::Repaid);
+}
+
+// ── Pure Math Function Tests ──
+
+#[test]
+fn test_calculate_interest_zero_principal() {
+    let interest = crate::repayment::calculate_interest(0, 1000, 31_536_000);
+    assert_eq!(interest, 0);
 }
 
 #[test]
-#[should_panic(expected = "repayment amount must be positive")]
-fn test_repayment_negative_amount() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
-
-    let nft_contract = Address::generate(&env);
-    manager.initialize(&nft_contract);
-
-    let borrower = Address::generate(&env);
-
-    // Should panic due to negative amount
-    manager.repay(&borrower, &-100);
+fn test_calculate_interest_zero_rate() {
+    let interest = crate::repayment::calculate_interest(100_000, 0, 31_536_000);
+    assert_eq!(interest, 0);
 }
 
 #[test]
-#[should_panic]
-fn test_access_controls_unauthorized_repay() {
-    let env = Env::default();
-    // NOT using mock_all_auths() to enforce actual signatures
+fn test_calculate_interest_zero_time() {
+    let interest = crate::repayment::calculate_interest(100_000, 1000, 0);
+    assert_eq!(interest, 0);
+}
 
-    let loan_manager_id = env.register(LoanManager, ());
-    let manager = LoanManagerClient::new(&env, &loan_manager_id);
+#[test]
+fn test_calculate_interest_one_year() {
+    // 10% on 100,000 for 1 year = 10,000
+    let interest = crate::repayment::calculate_interest(100_000, 1000, 31_536_000);
+    assert_eq!(interest, 10_000);
+}
 
-    let nft_contract = Address::generate(&env);
-    manager.initialize(&nft_contract);
+#[test]
+fn test_calculate_interest_quarter_year() {
+    // 10% on 100,000 for 3 months = 2,500
+    let interest = crate::repayment::calculate_interest(100_000, 1000, 31_536_000 / 4);
+    assert_eq!(interest, 2_500);
+}
 
-    let borrower = Address::generate(&env);
+#[test]
+fn test_calculate_outstanding_balance_no_repayment() {
+    let balance = crate::repayment::calculate_outstanding_balance(100_000, 1000, 0, 31_536_000, 0);
+    // 100,000 + 10,000 interest = 110,000
+    assert_eq!(balance, 110_000);
+}
 
-    // Attempting to repay without proper Authorization scope should panic natively.
-    manager.repay(&borrower, &500);
+#[test]
+fn test_calculate_outstanding_balance_with_repayment() {
+    let balance =
+        crate::repayment::calculate_outstanding_balance(100_000, 1000, 0, 31_536_000, 60_000);
+    // 100,000 + 10,000 - 60,000 = 50,000
+    assert_eq!(balance, 50_000);
+}
+
+#[test]
+fn test_calculate_outstanding_balance_overpaid_returns_zero() {
+    let balance =
+        crate::repayment::calculate_outstanding_balance(100_000, 1000, 0, 31_536_000, 200_000);
+    assert_eq!(balance, 0);
+}
+
+#[test]
+fn test_calculate_penalty_before_due() {
+    let penalty = crate::repayment::calculate_penalty(100_000, 500, 31_536_000, 0);
+    assert_eq!(penalty, 0);
+}
+
+#[test]
+fn test_calculate_penalty_at_due() {
+    let penalty = crate::repayment::calculate_penalty(100_000, 500, 31_536_000, 31_536_000);
+    assert_eq!(penalty, 0);
+}
+
+#[test]
+fn test_calculate_penalty_one_year_overdue() {
+    // 5% on 100,000 for 1 year overdue = 5,000
+    let penalty = crate::repayment::calculate_penalty(100_000, 500, 0, 31_536_000);
+    assert_eq!(penalty, 5_000);
 }

--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -15,6 +15,7 @@ pub enum DataKey {
     Score(Address), // Legacy key for backward compatibility
     Admin,
     AuthorizedMinter(Address),
+    CollateralLock(Address),
 }
 
 #[contract]
@@ -215,6 +216,84 @@ impl RemittanceNFT {
         metadata.score += points;
 
         env.storage().persistent().set(&metadata_key, &metadata);
+    }
+
+    pub fn lock_collateral(env: Env, user: Address, locker: Address) {
+        locker.require_auth();
+
+        let is_authorized: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::AuthorizedMinter(locker.clone()))
+            .unwrap_or(false);
+        if !is_authorized {
+            panic!("not authorized to manage collateral");
+        }
+
+        let has_nft = env
+            .storage()
+            .persistent()
+            .has(&DataKey::Metadata(user.clone()))
+            || env
+                .storage()
+                .persistent()
+                .has(&DataKey::Score(user.clone()));
+        if !has_nft {
+            panic!("user does not have an NFT");
+        }
+
+        let lock_key = DataKey::CollateralLock(user.clone());
+        if env.storage().persistent().has(&lock_key) {
+            panic!("collateral already locked");
+        }
+
+        env.storage().persistent().set(&lock_key, &locker);
+    }
+
+    pub fn unlock_collateral(env: Env, user: Address, locker: Address) {
+        locker.require_auth();
+
+        let lock_key = DataKey::CollateralLock(user.clone());
+        let current_locker: Address = env
+            .storage()
+            .persistent()
+            .get(&lock_key)
+            .expect("collateral not locked");
+
+        if current_locker != locker {
+            panic!("only the original locker can unlock");
+        }
+
+        env.storage().persistent().remove(&lock_key);
+    }
+
+    pub fn is_locked(env: Env, user: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::CollateralLock(user))
+    }
+
+    pub fn seize_collateral(env: Env, user: Address, locker: Address) {
+        locker.require_auth();
+
+        let lock_key = DataKey::CollateralLock(user.clone());
+        let current_locker: Address = env
+            .storage()
+            .persistent()
+            .get(&lock_key)
+            .expect("collateral not locked");
+
+        if current_locker != locker {
+            panic!("only the original locker can seize");
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Metadata(user.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Score(user.clone()));
+        env.storage().persistent().remove(&lock_key);
     }
 
     /// Update the history hash for a user's NFT

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -256,6 +256,241 @@ fn test_update_score_migrates_legacy_data() {
     assert_eq!(metadata.score, 602);
 }
 
+// ── Collateral Management Tests ──
+
+#[test]
+fn test_lock_collateral() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let loan_manager = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&loan_manager);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    assert!(!client.is_locked(&user));
+    client.lock_collateral(&user, &loan_manager);
+    assert!(client.is_locked(&user));
+}
+
+#[test]
+#[should_panic(expected = "collateral already locked")]
+fn test_lock_already_locked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let loan_manager = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&loan_manager);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    client.lock_collateral(&user, &loan_manager);
+    client.lock_collateral(&user, &loan_manager);
+}
+
+#[test]
+#[should_panic(expected = "user does not have an NFT")]
+fn test_lock_no_nft() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let loan_manager = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&loan_manager);
+
+    client.lock_collateral(&user, &loan_manager);
+}
+
+#[test]
+#[should_panic(expected = "not authorized to manage collateral")]
+fn test_lock_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let unauthorized = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    client.lock_collateral(&user, &unauthorized);
+}
+
+#[test]
+fn test_unlock_collateral() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let loan_manager = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&loan_manager);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    client.lock_collateral(&user, &loan_manager);
+    assert!(client.is_locked(&user));
+
+    client.unlock_collateral(&user, &loan_manager);
+    assert!(!client.is_locked(&user));
+}
+
+#[test]
+#[should_panic(expected = "collateral not locked")]
+fn test_unlock_not_locked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let loan_manager = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&loan_manager);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    client.unlock_collateral(&user, &loan_manager);
+}
+
+#[test]
+#[should_panic(expected = "only the original locker can unlock")]
+fn test_unlock_wrong_locker() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let locker1 = Address::generate(&env);
+    let locker2 = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&locker1);
+    client.authorize_minter(&locker2);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    client.lock_collateral(&user, &locker1);
+    client.unlock_collateral(&user, &locker2);
+}
+
+#[test]
+fn test_seize_collateral() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let loan_manager = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&loan_manager);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    client.lock_collateral(&user, &loan_manager);
+    client.seize_collateral(&user, &loan_manager);
+
+    assert!(!client.is_locked(&user));
+    assert!(client.get_metadata(&user).is_none());
+    assert_eq!(client.get_score(&user), 0);
+}
+
+#[test]
+#[should_panic(expected = "only the original locker can seize")]
+fn test_seize_wrong_locker() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let locker1 = Address::generate(&env);
+    let locker2 = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&locker1);
+    client.authorize_minter(&locker2);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    client.lock_collateral(&user, &locker1);
+    client.seize_collateral(&user, &locker2);
+}
+
+#[test]
+fn test_relock_after_unlock() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let loan_manager = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&loan_manager);
+
+    let hash = create_test_hash(&env, 1);
+    client.mint(&user, &500, &hash, &None);
+
+    client.lock_collateral(&user, &loan_manager);
+    client.unlock_collateral(&user, &loan_manager);
+    client.lock_collateral(&user, &loan_manager);
+    assert!(client.is_locked(&user));
+}
+
 #[test]
 fn test_update_history_hash_migrates_legacy_data() {
     let env = Env::default();


### PR DESCRIPTION
## Summary

- Adds `lock_collateral`, `unlock_collateral`, `is_locked`, and `seize_collateral` functions to the **remittance_nft** contract — only authorized minters (e.g. the loan_manager) can manage collateral
- Integrates collateral lifecycle into **loan_manager**: NFT is locked on `request_loan`, unlocked on full `repay`, and seized on `liquidate`
- Adds `liquidate` function to mark overdue Active loans as Defaulted and seize the borrower's NFT

Closes #4

> **Note:** This PR depends on #131 (repayment calculation logic). It includes those commits; once #131 is merged, this PR will show only the collateral changes.

## Implementation details

- **RemittanceNFT**: `CollateralLock(Address)` storage key maps a user to the locker contract. Lock/unlock/seize require the caller to be an authorized minter via `require_auth()`. Seize removes the NFT metadata entirely (burns the NFT)
- **LoanManager**: Cross-contract calls to the NFT contract for locking (`request_loan`), unlocking (`repay` on full payoff), and seizing (`liquidate`). Liquidation is permissionless — anyone can trigger it for an overdue loan
- **Events**: `CollateralLocked`, `CollateralUnlocked`, `LoanDefaulted`

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all 68 tests pass (6 lending_pool + 42 loan_manager + 20 remittance_nft)
- [x] NFT: lock/unlock/seize, already-locked rejection, no-NFT rejection, unauthorized rejection, wrong-locker rejection, re-lock after unlock
- [x] Loan manager: request locks collateral, second loan rejected while locked, partial repay keeps lock, full repay unlocks, new loan after repayment works
- [x] Liquidation: overdue loan defaults and seizes NFT, cannot liquidate before due, cannot liquidate repaid/requested/already-defaulted loans