### PR TITLE
feat(backend): add rate limiting middleware with proxy trust config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,20 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/remitlend
 # For running backend locally (npm run dev outside docker):
 # DATABASE_URL=postgres://postgres:postgres@localhost:5432/remitlend
+
+# Number of proxy hops to trust for client IP resolution (rate limiting).
+# Set to 1 behind a single reverse proxy / load balancer; leave unset for
+# direct (non-proxied) deployments. Accepts a hop count, true/false, or a
+# subnet/preset list (e.g. "loopback, 10.0.0.0/8").
+TRUST_PROXY=
+
+# Rate limiting overrides (all optional; fall back to safe defaults if unset
+# or invalid). Global limiter applies to every request; strict limiter
+# applies to sensitive endpoints (e.g. score updates, simulations); auth
+# limiter applies to /auth/register and /auth/login independently.
+# RATE_LIMIT_MAX=100
+# RATE_LIMIT_WINDOW_MINUTES=15
+# STRICT_RATE_LIMIT_MAX=10
+# STRICT_RATE_LIMIT_WINDOW_MINUTES=45
+# AUTH_RATE_LIMIT_MAX=10
+# AUTH_RATE_LIMIT_WINDOW_MINUTES=15

--- a/backend/src/__tests__/rateLimiter.test.ts
+++ b/backend/src/__tests__/rateLimiter.test.ts
@@ -65,6 +65,23 @@ describe("rateLimiter", () => {
     });
   });
 
+  describe("429 response body", () => {
+    it("matches the app-wide { success, message } error envelope", async () => {
+      const app = buildApp(1, 1);
+
+      await request(app).get("/").set("X-Forwarded-For", "5.5.5.5").expect(200);
+      const res = await request(app)
+        .get("/")
+        .set("X-Forwarded-For", "5.5.5.5")
+        .expect(429);
+
+      expect(res.body).toEqual({
+        success: false,
+        message: "Too many requests, please try again later.",
+      });
+    });
+  });
+
   describe("parseTrustProxy", () => {
     it("defaults to false when unset or empty", () => {
       expect(parseTrustProxy(undefined)).toBe(false);

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -1,6 +1,20 @@
 import rateLimit from "express-rate-limit";
 
 /**
+ * Parses a positive-integer env var, falling back to `fallback` when unset,
+ * empty, or not a positive integer — so a misconfigured deployment degrades
+ * to a safe known limit instead of an unlimited or NaN window.
+ */
+const parsePositiveInt = (
+  value: string | undefined,
+  fallback: number,
+): number => {
+  if (value === undefined || value.trim() === "") return fallback;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+/**
  * Builds an express-rate-limit middleware.
  *
  * Keying:
@@ -13,6 +27,10 @@ import rateLimit from "express-rate-limit";
  *   `standardHeaders` emits the IETF draft `RateLimit-*` headers so clients can
  *   see their remaining quota; the deprecated `X-RateLimit-*` headers are
  *   disabled.
+ *
+ * Response body:
+ *   Matches the app-wide error envelope (`{ success: false, message }`) used
+ *   by `errorHandler.ts`, so a 429 looks like every other error response.
  *
  * Store:
  *   This uses express-rate-limit's default in-memory store. That store is
@@ -33,9 +51,49 @@ export const createRateLimiter = (
     max,
     standardHeaders: true,
     legacyHeaders: false,
-    message: { error: "Too many requests, please try again later." },
+    message: {
+      success: false,
+      message: "Too many requests, please try again later.",
+    },
     ...options,
   });
 
-export const globalRateLimiter = createRateLimiter(100);
-export const strictRateLimiter = createRateLimiter(10, 45);
+// Env-configurable so limits can be tuned per deployment without a code
+// change; falls back to these known-safe defaults when unset or invalid.
+const GLOBAL_MAX = parsePositiveInt(process.env.RATE_LIMIT_MAX, 100);
+const GLOBAL_WINDOW_MINUTES = parsePositiveInt(
+  process.env.RATE_LIMIT_WINDOW_MINUTES,
+  15,
+);
+const STRICT_MAX = parsePositiveInt(process.env.STRICT_RATE_LIMIT_MAX, 10);
+const STRICT_WINDOW_MINUTES = parsePositiveInt(
+  process.env.STRICT_RATE_LIMIT_WINDOW_MINUTES,
+  45,
+);
+const AUTH_MAX = parsePositiveInt(process.env.AUTH_RATE_LIMIT_MAX, 10);
+const AUTH_WINDOW_MINUTES = parsePositiveInt(
+  process.env.AUTH_RATE_LIMIT_WINDOW_MINUTES,
+  15,
+);
+
+export const globalRateLimiter = createRateLimiter(
+  GLOBAL_MAX,
+  GLOBAL_WINDOW_MINUTES,
+);
+export const strictRateLimiter = createRateLimiter(
+  STRICT_MAX,
+  STRICT_WINDOW_MINUTES,
+);
+
+// Separate instances (not `strictRateLimiter`) so brute-force attempts against
+// one auth endpoint can't exhaust the other's quota, and so registration and
+// login are throttled independently of unrelated sensitive endpoints (score
+// updates, simulations) that also use `strictRateLimiter`.
+export const registerRateLimiter = createRateLimiter(
+  AUTH_MAX,
+  AUTH_WINDOW_MINUTES,
+);
+export const loginRateLimiter = createRateLimiter(
+  AUTH_MAX,
+  AUTH_WINDOW_MINUTES,
+);

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -3,6 +3,10 @@ import { register, login, me } from "../controllers/authController.js";
 import { validate } from "../middleware/validation.js";
 import { registerSchema, loginSchema } from "../schemas/authSchemas.js";
 import { requireAuth } from "../middleware/auth.js";
+import {
+  registerRateLimiter,
+  loginRateLimiter,
+} from "../middleware/rateLimiter.js";
 
 const router = Router();
 
@@ -57,7 +61,12 @@ const router = Router();
  *       409:
  *         description: Email already registered.
  */
-router.post("/register", validate(registerSchema), register);
+router.post(
+  "/register",
+  registerRateLimiter,
+  validate(registerSchema),
+  register,
+);
 
 /**
  * @swagger
@@ -109,7 +118,7 @@ router.post("/register", validate(registerSchema), register);
  *       401:
  *         description: Invalid credentials.
  */
-router.post("/login", validate(loginSchema), login);
+router.post("/login", loginRateLimiter, validate(loginSchema), login);
 
 /**
  * @swagger


### PR DESCRIPTION
# closes #23
## Summary
Resolves #23. Most of the core rate-limiting setup (express-rate-limit, per-IP keying, `trust proxy` config via `TRUST_PROXY`) was already added in a prior fix for #96. This PR closes the remaining gaps against #23's acceptance criteria:

- Uniform 429 response body — now matches the app-wide error envelope (`{ success: false, message }`) used by `errorHandler.ts`, instead of a bespoke `{ error }` shape.
- Env-configurable limits — `RATE_LIMIT_MAX`, `RATE_LIMIT_WINDOW_MINUTES`, `STRICT_RATE_LIMIT_*`, `AUTH_RATE_LIMIT_*`, all falling back to the existing safe defaults (100/15min, 10/45min) when unset or invalid.
- Dedicated rate limiters on `/auth/register` and `/auth/login`, kept independent from `strictRateLimiter` and each other, so brute-force protection on auth doesn't share (or get starved by) another endpoint's quota.
- Restored `TRUST_PROXY` documentation in `.env.example`, which was silently dropped in an earlier merge conflict resolution.

## Test plan
- [x] `npm run build` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 76/76 passing, including a new assertion on the 429 body shape