### PR TITLE
optimize(contracts): refactor contract state storage models for rent efficiency

### DIFF
--- a/contracts/loan_manager/src/lib.rs
+++ b/contracts/loan_manager/src/lib.rs
@@ -6,17 +6,20 @@ pub mod repayment;
 
 const MIN_SCORE: u32 = 50;
 
+/// Tuple layout (id, borrower, amount, outstanding, interest_rate, status, created_at).
+/// Kept field-name-free so persisted entries serialize as an ScVec instead of an
+/// ScMap with per-field Symbol keys, shrinking the on-chain footprint of every loan.
 #[contracttype]
 #[derive(Clone)]
-pub struct LoanRecord {
-    pub id: u64,
-    pub borrower: Address,
-    pub amount: i128,
-    pub outstanding: i128,
-    pub interest_rate: u32,
-    pub status: LoanStatus,
-    pub created_at: u64,
-}
+pub struct LoanRecord(
+    pub u64,
+    pub Address,
+    pub i128,
+    pub i128,
+    pub u32,
+    pub LoanStatus,
+    pub u64,
+);
 
 #[contracttype]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -91,15 +94,15 @@ impl LoanManager {
         );
 
         // Create loan record
-        let loan = LoanRecord {
-            id: loan_id,
-            borrower: borrower.clone(),
+        let loan = LoanRecord(
+            loan_id,
+            borrower.clone(),
             amount,
-            outstanding: amount,
-            interest_rate: 500, // 5% default
-            status: LoanStatus::Requested,
-            created_at: env.ledger().timestamp(),
-        };
+            amount,
+            500, // 5% default interest rate
+            LoanStatus::Requested,
+            env.ledger().timestamp(),
+        );
 
         env.storage()
             .persistent()
@@ -121,11 +124,11 @@ impl LoanManager {
             .get(&loan_key)
             .expect("loan not found");
 
-        if loan.status != LoanStatus::Requested {
+        if loan.5 != LoanStatus::Requested {
             panic!("loan must be in Requested status");
         }
 
-        loan.status = LoanStatus::Active;
+        loan.5 = LoanStatus::Active;
         env.storage().persistent().set(&loan_key, &loan);
 
         events::loan_approved(&env, loan_id);
@@ -153,7 +156,7 @@ impl LoanManager {
                 .persistent()
                 .get::<DataKey, LoanRecord>(&DataKey::Loan(i))
             {
-                if loan.borrower == borrower && loan.status == LoanStatus::Active {
+                if loan.1 == borrower && loan.5 == LoanStatus::Active {
                     found_loan = Some((i, loan));
                     break;
                 }
@@ -162,15 +165,15 @@ impl LoanManager {
 
         let (loan_id, mut loan) = found_loan.expect("no active loan found");
 
-        if amount > loan.outstanding {
+        if amount > loan.3 {
             panic!("repayment exceeds outstanding amount");
         }
 
-        loan.outstanding -= amount;
+        loan.3 -= amount;
 
         // If fully repaid, unlock collateral
-        if loan.outstanding <= 0 {
-            loan.status = LoanStatus::Repaid;
+        if loan.3 <= 0 {
+            loan.5 = LoanStatus::Repaid;
 
             let nft_contract: Address = env
                 .storage()
@@ -205,11 +208,11 @@ impl LoanManager {
             .get(&loan_key)
             .expect("loan not found");
 
-        if loan.status != LoanStatus::Active {
+        if loan.5 != LoanStatus::Active {
             panic!("loan must be Active to default");
         }
 
-        loan.status = LoanStatus::Defaulted;
+        loan.5 = LoanStatus::Defaulted;
         env.storage().persistent().set(&loan_key, &loan);
 
         // Liquidate collateral
@@ -224,7 +227,7 @@ impl LoanManager {
             &Symbol::new(&env, "liquidate_collateral"),
             soroban_sdk::vec![
                 &env,
-                loan.borrower.clone().into_val(&env),
+                loan.1.clone().into_val(&env),
                 loan_id.into_val(&env),
                 env.current_contract_address().into_val(&env),
             ],

--- a/contracts/loan_manager/src/test.rs
+++ b/contracts/loan_manager/src/test.rs
@@ -83,10 +83,10 @@ fn test_loan_request_success() {
     assert_eq!(loan_id, 1);
 
     let loan = manager.get_loan(&loan_id).unwrap();
-    assert_eq!(loan.borrower, borrower);
-    assert_eq!(loan.amount, 1000);
-    assert_eq!(loan.outstanding, 1000);
-    assert_eq!(loan.status, LoanStatus::Requested);
+    assert_eq!(loan.1, borrower);
+    assert_eq!(loan.2, 1000);
+    assert_eq!(loan.3, 1000);
+    assert_eq!(loan.5, LoanStatus::Requested);
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn test_approve_loan_flow() {
     manager.approve_loan(&loan_id);
 
     let loan = manager.get_loan(&loan_id).unwrap();
-    assert_eq!(loan.status, LoanStatus::Active);
+    assert_eq!(loan.5, LoanStatus::Active);
 }
 
 // ── Repayment Tests ──
@@ -169,8 +169,8 @@ fn test_partial_repayment_reduces_outstanding() {
     manager.repay(&borrower, &0, &500);
 
     let loan = manager.get_loan(&loan_id).unwrap();
-    assert_eq!(loan.outstanding, 500);
-    assert_eq!(loan.status, LoanStatus::Active);
+    assert_eq!(loan.3, 500);
+    assert_eq!(loan.5, LoanStatus::Active);
 }
 
 #[test]
@@ -187,8 +187,8 @@ fn test_loan_full_repayment_unlocks_collateral() {
     manager.repay(&borrower, &0, &1000);
 
     let loan = manager.get_loan(&loan_id).unwrap();
-    assert_eq!(loan.status, LoanStatus::Repaid);
-    assert_eq!(loan.outstanding, 0);
+    assert_eq!(loan.5, LoanStatus::Repaid);
+    assert_eq!(loan.3, 0);
     assert!(!nft_client.is_locked(&borrower));
 }
 
@@ -235,7 +235,7 @@ fn test_loan_default_liquidates_collateral() {
     manager.default_loan(&loan_id);
 
     let loan = manager.get_loan(&loan_id).unwrap();
-    assert_eq!(loan.status, LoanStatus::Defaulted);
+    assert_eq!(loan.5, LoanStatus::Defaulted);
 
     // NFT should be seized (score gone, not locked)
     assert_eq!(nft_client.get_score(&borrower), 0);

--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -1,19 +1,17 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
 
+/// Tuple layout (score, history_hash). Avoids the per-field Symbol keys that a
+/// named-field struct would incur on every persisted NFT entry.
 #[contracttype]
 #[derive(Clone)]
-pub struct RemittanceMetadata {
-    pub score: u32,
-    pub history_hash: BytesN<32>,
-}
+pub struct RemittanceMetadata(pub u32, pub BytesN<32>);
 
+/// Tuple layout (locked, loan_id). Avoids the per-field Symbol keys that a
+/// named-field struct would incur on every persisted collateral entry.
 #[contracttype]
 #[derive(Clone)]
-pub struct CollateralInfo {
-    pub locked: bool,
-    pub loan_id: u64,
-}
+pub struct CollateralInfo(pub bool, pub u64);
 
 #[contracttype]
 #[derive(Clone)]
@@ -21,7 +19,7 @@ pub enum DataKey {
     Metadata(Address),
     Score(Address), // Legacy key for backward compatibility
     Admin,
-    AuthorizedMinter(Address),
+    Minter(Address),
     Collateral(Address), // Track collateral state for each user
 }
 
@@ -38,7 +36,7 @@ impl RemittanceNFT {
         // Admin is automatically authorized to mint
         env.storage()
             .instance()
-            .set(&DataKey::AuthorizedMinter(admin.clone()), &true);
+            .set(&DataKey::Minter(admin.clone()), &true);
     }
 
     /// Authorize a contract or account to mint NFTs
@@ -52,7 +50,7 @@ impl RemittanceNFT {
 
         env.storage()
             .instance()
-            .set(&DataKey::AuthorizedMinter(minter), &true);
+            .set(&DataKey::Minter(minter), &true);
     }
 
     /// Revoke authorization for a contract or account to mint NFTs
@@ -66,14 +64,14 @@ impl RemittanceNFT {
 
         env.storage()
             .instance()
-            .remove(&DataKey::AuthorizedMinter(minter));
+            .remove(&DataKey::Minter(minter));
     }
 
     /// Check if an address is authorized to mint
     pub fn is_authorized_minter(env: Env, minter: Address) -> bool {
         env.storage()
             .instance()
-            .get(&DataKey::AuthorizedMinter(minter))
+            .get(&DataKey::Minter(minter))
             .unwrap_or(false)
     }
 
@@ -100,7 +98,7 @@ impl RemittanceNFT {
             let is_authorized = env
                 .storage()
                 .instance()
-                .get(&DataKey::AuthorizedMinter(minter_addr))
+                .get(&DataKey::Minter(minter_addr))
                 .unwrap_or(false);
             if !is_authorized {
                 panic!("minter is not authorized");
@@ -120,10 +118,7 @@ impl RemittanceNFT {
             panic!("user already has an NFT");
         }
 
-        let metadata = RemittanceMetadata {
-            score: initial_score,
-            history_hash,
-        };
+        let metadata = RemittanceMetadata(initial_score, history_hash);
 
         env.storage().persistent().set(&metadata_key, &metadata);
     }
@@ -140,10 +135,7 @@ impl RemittanceNFT {
         if let Some(score) = env.storage().persistent().get::<DataKey, u32>(&score_key) {
             // Migrate old Score to new Metadata format
             let default_hash = BytesN::from_array(&env, &[0u8; 32]); // Zero hash as default
-            let migrated_metadata = RemittanceMetadata {
-                score,
-                history_hash: default_hash,
-            };
+            let migrated_metadata = RemittanceMetadata(score, default_hash);
             // Store migrated metadata
             env.storage()
                 .persistent()
@@ -160,7 +152,7 @@ impl RemittanceNFT {
     /// Handles backward compatibility by checking Metadata first, then legacy Score data
     pub fn get_score(env: Env, user: Address) -> u32 {
         if let Some(metadata) = Self::get_metadata(env.clone(), user.clone()) {
-            return metadata.score;
+            return metadata.0;
         }
 
         // Check legacy Score data (shouldn't happen after migration, but safe fallback)
@@ -188,7 +180,7 @@ impl RemittanceNFT {
             let is_authorized = env
                 .storage()
                 .instance()
-                .get(&DataKey::AuthorizedMinter(minter_addr))
+                .get(&DataKey::Minter(minter_addr))
                 .unwrap_or(false);
             if !is_authorized {
                 panic!("minter is not authorized");
@@ -207,10 +199,7 @@ impl RemittanceNFT {
         } else if let Some(score) = env.storage().persistent().get::<DataKey, u32>(&score_key) {
             // Migrate legacy Score to Metadata
             let default_hash = BytesN::from_array(&env, &[0u8; 32]);
-            let migrated = RemittanceMetadata {
-                score,
-                history_hash: default_hash,
-            };
+            let migrated = RemittanceMetadata(score, default_hash);
             env.storage().persistent().set(&metadata_key, &migrated);
             env.storage().persistent().remove(&score_key);
             migrated
@@ -220,7 +209,7 @@ impl RemittanceNFT {
 
         // Simple logic: 1 point per 100 units of repayment
         let points = (repayment_amount / 100) as u32;
-        metadata.score += points;
+        metadata.0 += points;
 
         env.storage().persistent().set(&metadata_key, &metadata);
     }
@@ -247,7 +236,7 @@ impl RemittanceNFT {
             let is_authorized = env
                 .storage()
                 .instance()
-                .get(&DataKey::AuthorizedMinter(minter_addr))
+                .get(&DataKey::Minter(minter_addr))
                 .unwrap_or(false);
             if !is_authorized {
                 panic!("minter is not authorized");
@@ -266,10 +255,7 @@ impl RemittanceNFT {
         } else if let Some(score) = env.storage().persistent().get::<DataKey, u32>(&score_key) {
             // Migrate legacy Score to Metadata
             let default_hash = BytesN::from_array(&env, &[0u8; 32]);
-            let migrated = RemittanceMetadata {
-                score,
-                history_hash: default_hash,
-            };
+            let migrated = RemittanceMetadata(score, default_hash);
             env.storage().persistent().set(&metadata_key, &migrated);
             env.storage().persistent().remove(&score_key);
             migrated
@@ -277,7 +263,7 @@ impl RemittanceNFT {
             panic!("user does not have an NFT");
         };
 
-        metadata.history_hash = new_history_hash;
+        metadata.1 = new_history_hash;
 
         env.storage().persistent().set(&metadata_key, &metadata);
     }
@@ -297,7 +283,7 @@ impl RemittanceNFT {
         let is_authorized = env
             .storage()
             .instance()
-            .get(&DataKey::AuthorizedMinter(locker))
+            .get(&DataKey::Minter(locker))
             .unwrap_or(false);
         if !is_authorized {
             panic!("locker is not authorized");
@@ -317,15 +303,12 @@ impl RemittanceNFT {
             .persistent()
             .get::<DataKey, CollateralInfo>(&collateral_key)
         {
-            if collateral.locked {
+            if collateral.0 {
                 panic!("collateral already locked");
             }
         }
 
-        let collateral_info = CollateralInfo {
-            locked: true,
-            loan_id,
-        };
+        let collateral_info = CollateralInfo(true, loan_id);
 
         env.storage()
             .persistent()
@@ -346,7 +329,7 @@ impl RemittanceNFT {
         let is_authorized = env
             .storage()
             .instance()
-            .get(&DataKey::AuthorizedMinter(locker))
+            .get(&DataKey::Minter(locker))
             .unwrap_or(false);
         if !is_authorized {
             panic!("locker is not authorized");
@@ -360,20 +343,17 @@ impl RemittanceNFT {
             .persistent()
             .get::<DataKey, CollateralInfo>(&collateral_key)
         {
-            if !collateral.locked {
+            if !collateral.0 {
                 panic!("collateral is not locked");
             }
-            if collateral.loan_id != loan_id {
+            if collateral.1 != loan_id {
                 panic!("collateral locked for different loan");
             }
         } else {
             panic!("collateral info not found");
         }
 
-        let unlocked_collateral = CollateralInfo {
-            locked: false,
-            loan_id,
-        };
+        let unlocked_collateral = CollateralInfo(false, loan_id);
 
         env.storage()
             .persistent()
@@ -395,7 +375,7 @@ impl RemittanceNFT {
         let is_authorized = env
             .storage()
             .instance()
-            .get(&DataKey::AuthorizedMinter(liquidator))
+            .get(&DataKey::Minter(liquidator))
             .unwrap_or(false);
         if !is_authorized {
             panic!("liquidator is not authorized");
@@ -409,10 +389,10 @@ impl RemittanceNFT {
             .persistent()
             .get::<DataKey, CollateralInfo>(&collateral_key)
         {
-            if !collateral.locked {
+            if !collateral.0 {
                 panic!("collateral is not locked");
             }
-            if collateral.loan_id != loan_id {
+            if collateral.1 != loan_id {
                 panic!("collateral locked for different loan");
             }
         } else {
@@ -431,7 +411,7 @@ impl RemittanceNFT {
             .persistent()
             .get::<DataKey, CollateralInfo>(&collateral_key)
         {
-            return collateral.locked;
+            return collateral.0;
         }
         false
     }
@@ -444,8 +424,8 @@ impl RemittanceNFT {
             .persistent()
             .get::<DataKey, CollateralInfo>(&collateral_key)
         {
-            if collateral.locked {
-                return Some(collateral.loan_id);
+            if collateral.0 {
+                return Some(collateral.1);
             }
         }
         None

--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -62,9 +62,7 @@ impl RemittanceNFT {
             .expect("not initialized");
         admin.require_auth();
 
-        env.storage()
-            .instance()
-            .remove(&DataKey::Minter(minter));
+        env.storage().instance().remove(&DataKey::Minter(minter));
     }
 
     /// Check if an address is authorized to mint

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -29,8 +29,8 @@ fn test_score_lifecycle() {
 
     // Check metadata
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.score, 500);
-    assert_eq!(metadata.history_hash, history_hash);
+    assert_eq!(metadata.0, 500);
+    assert_eq!(metadata.1, history_hash);
 
     // Update score (repayment of 250 -> 2 points) - admin updates
     client.update_score(&user, &250, &None);
@@ -38,7 +38,7 @@ fn test_score_lifecycle() {
 
     // Verify metadata updated
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.score, 502);
+    assert_eq!(metadata.0, 502);
 
     // Update score (repayment of 1000 -> 10 points) - admin updates
     client.update_score(&user, &1000, &None);
@@ -46,7 +46,7 @@ fn test_score_lifecycle() {
 
     // Verify metadata updated
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.score, 512);
+    assert_eq!(metadata.0, 512);
 
     // Unregistered user should have 0 score
     let stranger = Address::generate(&env);
@@ -71,15 +71,15 @@ fn test_history_hash_update() {
     client.mint(&user, &500, &initial_hash, &None);
 
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.history_hash, initial_hash);
+    assert_eq!(metadata.1, initial_hash);
 
     // Update history hash - admin updates
     let new_hash = create_test_hash(&env, 2);
     client.update_history_hash(&user, &new_hash, &None);
 
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.history_hash, new_hash);
-    assert_eq!(metadata.score, 500); // Score should remain unchanged
+    assert_eq!(metadata.1, new_hash);
+    assert_eq!(metadata.0, 500); // Score should remain unchanged
 }
 
 #[test]
@@ -254,8 +254,8 @@ fn test_get_metadata_migrates_legacy_score() {
     });
 
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.score, 777);
-    assert_eq!(metadata.history_hash, BytesN::from_array(&env, &[0u8; 32]));
+    assert_eq!(metadata.0, 777);
+    assert_eq!(metadata.1, BytesN::from_array(&env, &[0u8; 32]));
 
     env.as_contract(&contract_id, || {
         assert!(!env.storage().persistent().has(&score_key));
@@ -288,10 +288,10 @@ fn test_backward_compatibility_migration() {
 
     // get_metadata should return migrated metadata with default hash
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.score, 750);
+    assert_eq!(metadata.0, 750);
     // Verify default hash (all zeros)
     let expected_default_hash = BytesN::from_array(&env, &[0u8; 32]);
-    assert_eq!(metadata.history_hash, expected_default_hash);
+    assert_eq!(metadata.1, expected_default_hash);
 
     // Verify old Score key is removed after migration
     env.as_contract(&contract_id, || {
@@ -308,7 +308,7 @@ fn test_backward_compatibility_migration() {
 
     // Verify metadata still exists and is updated
     let updated_metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(updated_metadata.score, 755);
+    assert_eq!(updated_metadata.0, 755);
 }
 
 #[test]
@@ -345,7 +345,7 @@ fn test_update_score_migrates_legacy_data() {
     });
 
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.score, 602);
+    assert_eq!(metadata.0, 602);
 }
 
 #[test]
@@ -374,8 +374,8 @@ fn test_update_history_hash_migrates_legacy_data() {
 
     // Verify migration and update
     let metadata = client.get_metadata(&user).unwrap();
-    assert_eq!(metadata.score, 800); // Score preserved
-    assert_eq!(metadata.history_hash, new_hash); // Hash updated
+    assert_eq!(metadata.0, 800); // Score preserved
+    assert_eq!(metadata.1, new_hash); // Hash updated
 
     // Verify old data is gone
     env.as_contract(&contract_id, || {


### PR DESCRIPTION
# closes #16 
## Summary
- Resolves #16 — audits and repacks Soroban storage schemas across `contracts/` to shrink per-entry serialization footprint and reduce network rent.
- `loan_manager::LoanRecord`, `remittance_nft::RemittanceMetadata`, and `remittance_nft::CollateralInfo` converted from named-field `#[contracttype]` structs to tuple structs. Named-field structs serialize as an `ScVal::Map` with an `ScSymbol` key per field; tuple structs serialize as a plain `ScVal::Vec` with no field-name overhead. This removes ~7 field-name symbols per loan entry and ~2-4 per NFT/collateral entry, scaling with loan volume and user count.
- `remittance_nft::DataKey::AuthorizedMinter(Address)` renamed to `DataKey::Minter(Address)`, shrinking the on-chain key for every authorized minter (16-char variant name → 6 chars).
- `lending_pool` was audited but left unchanged — its `DataKey` stores only primitives (`i128`, `Address`) with no structs, and is already minimal.

## Non-goals (kept out of scope on purpose)
- Did not remove the redundant `LoanRecord.id` field (duplicates the storage key) — doing so would shrink the public `get_loan()` return arity, which crosses into interface/business-logic territory.
- Did not collapse `CollateralInfo.locked` into "entry presence" — that would silently change which panic message fires on a double-unlock (an observable behavior change), so the explicit bool is preserved.
- Did not rename the legacy `DataKey::Score` key in `remittance_nft` — it intentionally matches the pre-migration on-chain key name for backward compatibility.

No control flow, auth checks, or panic/revert conditions were changed — only the wire representation of persisted state and one key's naming.

## Test plan
- [x] `cargo build --workspace` — clean build
- [x] `cargo test` (from `contracts/`) — 44/44 tests pass (9 lending_pool, 12 loan_manager, 23 remittance_nft), zero compilation or serialization errors