### PR TITLE
#6 #11 add remittance NFT issuance flow and tests

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -133,41 +133,64 @@ cargo tarpaulin --out Html
 
 ### 1. Remittance NFT Contract
 
-**Purpose**: Mint and manage NFTs representing borrower credit scores.
+**Purpose**: Issue and manage NFTs representing borrower credit scores and remittance history.
 
 **Key Functions**:
 ```rust
 // Initialize the contract
 pub fn initialize(env: Env, admin: Address)
 
-// Mint a new NFT
-pub fn mint_nft(env: Env, owner: Address, score: u32) -> u64
+// Issue a new remittance NFT
+pub fn issue_nft(
+    env: Env,
+    user: Address,
+    initial_score: u32,
+    history_hash: BytesN<32>,
+    issuer: Option<Address>,
+)
 
-// Update credit score
-pub fn update_score(env: Env, nft_id: u64, new_score: u32)
+// Backward-compatible alias for existing integrations
+pub fn mint(
+    env: Env,
+    user: Address,
+    initial_score: u32,
+    history_hash: BytesN<32>,
+    minter: Option<Address>,
+)
+
+// Check whether a wallet already has an issued NFT
+pub fn has_nft(env: Env, user: Address) -> bool
+
+// Read the stored metadata for a wallet
+pub fn get_metadata(env: Env, user: Address) -> Option<RemittanceMetadata>
+
+// Get the credit score for a wallet
+pub fn get_score(env: Env, user: Address) -> u32
+
+// Update credit score after repayment activity
+pub fn update_score(env: Env, user: Address, repayment_amount: i128, minter: Option<Address>)
 
 // Update remittance history hash
-pub fn update_history_hash(env: Env, nft_id: u64, hash: BytesN<32>)
+pub fn update_history_hash(
+    env: Env,
+    user: Address,
+    new_history_hash: BytesN<32>,
+    minter: Option<Address>,
+)
 
-// Get NFT score
-pub fn get_score(env: Env, nft_id: u64) -> u32
-
-// Lock NFT (for loan collateral)
-pub fn lock_nft(env: Env, nft_id: u64)
-
-// Unlock NFT (after loan repayment)
-pub fn unlock_nft(env: Env, nft_id: u64)
+// Lock and unlock NFT collateral by wallet address
+pub fn lock_collateral(env: Env, user: Address, loan_id: u64, locker: Address)
+pub fn unlock_collateral(env: Env, user: Address, loan_id: u64, locker: Address)
 ```
 
 **Storage Keys**:
-- `NFT_COUNTER` - Total NFTs minted
-- `NFT_OWNER_{id}` - NFT ownership mapping
-- `NFT_SCORE_{id}` - Credit score storage
-- `NFT_HASH_{id}` - Remittance history hash
-- `NFT_LOCKED_{id}` - Lock status
+- `Metadata(Address)` - Score plus remittance history hash
+- `Score(Address)` - Legacy score-only storage, auto-migrated on read/write
+- `Collateral(Address)` - Locked collateral state and associated loan ID
+- `AuthorizedMinter(Address)` - Admin-approved issuers / loan manager contracts
 
 **Tests**:
-- ✅ Mint NFT flow
+- ✅ NFT issuance flow
 - ✅ Update score
 - ✅ Update history hash
 - ✅ Lock/unlock NFT

--- a/contracts/remittance_nft/src/events.rs
+++ b/contracts/remittance_nft/src/events.rs
@@ -1,0 +1,6 @@
+use soroban_sdk::{Address, BytesN, Env, Symbol};
+
+pub fn nft_issued(env: &Env, owner: Address, score: u32, history_hash: BytesN<32>) {
+    let topics = (Symbol::new(env, "NftIssued"), owner);
+    env.events().publish(topics, (score, history_hash));
+}

--- a/contracts/remittance_nft/src/lib.rs
+++ b/contracts/remittance_nft/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env};
 
+mod events;
+
 #[contracttype]
 #[derive(Clone)]
 pub struct RemittanceMetadata {
@@ -77,10 +79,22 @@ impl RemittanceNFT {
             .unwrap_or(false)
     }
 
-    /// Mint an NFT representing a user's remittance history and reputation score
-    /// Only authorized contracts/accounts can call this function
-    /// If minter is provided, it must be authorized and must authorize the call
-    /// If minter is None, admin must authorize the call
+    /// Issue a remittance NFT for a borrower.
+    /// Only the admin or an authorized issuer can issue an NFT.
+    pub fn issue_nft(
+        env: Env,
+        user: Address,
+        initial_score: u32,
+        history_hash: BytesN<32>,
+        issuer: Option<Address>,
+    ) {
+        let admin = Self::get_admin(&env);
+        Self::require_authorized_actor(&env, &admin, issuer, "issuer is not authorized");
+        Self::issue_nft_internal(env, user, initial_score, history_hash);
+    }
+
+    /// Backward-compatible alias for NFT issuance.
+    /// Existing integrations may still call `mint`, so keep the old entrypoint.
     pub fn mint(
         env: Env,
         user: Address,
@@ -88,44 +102,9 @@ impl RemittanceNFT {
         history_hash: BytesN<32>,
         minter: Option<Address>,
     ) {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("not initialized");
-
-        if let Some(minter_addr) = minter {
-            // If minter is provided, require their auth and check authorization
-            minter_addr.require_auth();
-            let is_authorized = env
-                .storage()
-                .instance()
-                .get(&DataKey::AuthorizedMinter(minter_addr))
-                .unwrap_or(false);
-            if !is_authorized {
-                panic!("minter is not authorized");
-            }
-        } else {
-            // If no minter provided, require admin auth
-            admin.require_auth();
-        }
-
-        let metadata_key = DataKey::Metadata(user.clone());
-        let score_key = DataKey::Score(user.clone());
-
-        // Check if user already has an NFT (either new format or legacy)
-        if env.storage().persistent().has(&metadata_key)
-            || env.storage().persistent().has(&score_key)
-        {
-            panic!("user already has an NFT");
-        }
-
-        let metadata = RemittanceMetadata {
-            score: initial_score,
-            history_hash,
-        };
-
-        env.storage().persistent().set(&metadata_key, &metadata);
+        let admin = Self::get_admin(&env);
+        Self::require_authorized_actor(&env, &admin, minter, "minter is not authorized");
+        Self::issue_nft_internal(env, user, initial_score, history_hash);
     }
 
     /// Get the metadata (score and history hash) for a user's NFT
@@ -169,6 +148,15 @@ impl RemittanceNFT {
             .persistent()
             .get::<DataKey, u32>(&score_key)
             .unwrap_or(0)
+    }
+
+    /// Check whether a user already has a remittance NFT.
+    /// Legacy score-only records count as an issued NFT so callers can
+    /// safely gate issuance before migration happens.
+    pub fn has_nft(env: Env, user: Address) -> bool {
+        let metadata_key = DataKey::Metadata(user.clone());
+        let score_key = DataKey::Score(user);
+        env.storage().persistent().has(&metadata_key) || env.storage().persistent().has(&score_key)
     }
 
     /// Update the score for a user's NFT
@@ -453,3 +441,49 @@ impl RemittanceNFT {
 }
 
 mod test;
+
+impl RemittanceNFT {
+    fn issue_nft_internal(env: Env, user: Address, initial_score: u32, history_hash: BytesN<32>) {
+        if Self::has_nft(env.clone(), user.clone()) {
+            panic!("user already has an NFT");
+        }
+
+        let metadata = RemittanceMetadata {
+            score: initial_score,
+            history_hash: history_hash.clone(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Metadata(user.clone()), &metadata);
+        events::nft_issued(&env, user, initial_score, history_hash);
+    }
+
+    fn get_admin(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    fn require_authorized_actor(
+        env: &Env,
+        admin: &Address,
+        actor: Option<Address>,
+        unauthorized_message: &str,
+    ) {
+        if let Some(actor_addr) = actor {
+            actor_addr.require_auth();
+            let is_authorized = env
+                .storage()
+                .instance()
+                .get(&DataKey::AuthorizedMinter(actor_addr))
+                .unwrap_or(false);
+            if !is_authorized {
+                panic!("{}", unauthorized_message);
+            }
+        } else {
+            admin.require_auth();
+        }
+    }
+}

--- a/contracts/remittance_nft/src/test.rs
+++ b/contracts/remittance_nft/src/test.rs
@@ -1,11 +1,89 @@
 #![cfg(test)]
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Events as _},
+    vec, Address, BytesN, Env, IntoVal, Symbol,
+};
 
 fn create_test_hash(env: &Env, value: u8) -> BytesN<32> {
     let mut hash_bytes = [0u8; 32];
     hash_bytes[0] = value;
     BytesN::from_array(env, &hash_bytes)
+}
+
+#[test]
+fn test_has_nft_is_false_before_issuance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    assert!(!client.has_nft(&user));
+    assert!(client.get_metadata(&user).is_none());
+    assert_eq!(client.get_score(&user), 0);
+}
+
+#[test]
+fn test_issue_nft_with_authorized_issuer_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.authorize_minter(&issuer);
+
+    let history_hash = create_test_hash(&env, 9);
+    client.issue_nft(&user, &720, &history_hash, &Some(issuer));
+
+    assert!(client.has_nft(&user));
+
+    let metadata = client.get_metadata(&user).unwrap();
+    assert_eq!(metadata.score, 720);
+    assert_eq!(metadata.history_hash, history_hash);
+}
+
+#[test]
+fn test_issue_nft_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let history_hash = create_test_hash(&env, 11);
+    client.issue_nft(&user, &680, &history_hash, &None);
+
+    let expected_topics = (Symbol::new(&env, "NftIssued"), user.clone());
+    let expected_data = (680u32, history_hash);
+
+    assert_eq!(
+        env.events().all(),
+        vec![
+            &env,
+            (
+                contract_id.clone(),
+                expected_topics.into_val(&env),
+                expected_data.into_val(&env),
+            ),
+        ]
+    );
 }
 
 #[test]
@@ -23,9 +101,10 @@ fn test_score_lifecycle() {
 
     let history_hash = create_test_hash(&env, 1);
 
-    // Initial mint (admin mints, so minter is None)
-    client.mint(&user, &500, &history_hash, &None);
+    // Initial issuance (admin issues, so issuer is None)
+    client.issue_nft(&user, &500, &history_hash, &None);
     assert_eq!(client.get_score(&user), 500);
+    assert!(client.has_nft(&user));
 
     // Check metadata
     let metadata = client.get_metadata(&user).unwrap();
@@ -68,7 +147,7 @@ fn test_history_hash_update() {
     client.initialize(&admin);
 
     let initial_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &initial_hash, &None);
+    client.issue_nft(&user, &500, &initial_hash, &None);
 
     let metadata = client.get_metadata(&user).unwrap();
     assert_eq!(metadata.history_hash, initial_hash);
@@ -146,11 +225,11 @@ fn test_duplicate_mint() {
     client.initialize(&admin);
 
     let history_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &history_hash, &None);
+    client.issue_nft(&user, &500, &history_hash, &None);
 
     // Try to mint again for the same user
     let history_hash2 = create_test_hash(&env, 2);
-    client.mint(&user, &600, &history_hash2, &None);
+    client.issue_nft(&user, &600, &history_hash2, &None);
 }
 
 #[test]
@@ -190,8 +269,8 @@ fn test_update_history_hash_without_nft() {
 }
 
 #[test]
-#[should_panic(expected = "minter is not authorized")]
-fn test_mint_with_unauthorized_minter_panics() {
+#[should_panic(expected = "issuer is not authorized")]
+fn test_issue_nft_with_unauthorized_issuer_panics() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -205,6 +284,25 @@ fn test_mint_with_unauthorized_minter_panics() {
     client.initialize(&admin);
 
     let history_hash = create_test_hash(&env, 7);
+    client.issue_nft(&user, &500, &history_hash, &Some(unauthorized_minter));
+}
+
+#[test]
+#[should_panic(expected = "minter is not authorized")]
+fn test_legacy_mint_with_unauthorized_minter_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let unauthorized_minter = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let history_hash = create_test_hash(&env, 17);
     client.mint(&user, &500, &history_hash, &Some(unauthorized_minter));
 }
 
@@ -225,10 +323,33 @@ fn test_update_with_revoked_minter_panics() {
     client.authorize_minter(&minter);
 
     let history_hash = create_test_hash(&env, 8);
-    client.mint(&user, &500, &history_hash, &Some(minter.clone()));
+    client.issue_nft(&user, &500, &history_hash, &Some(minter.clone()));
 
     client.revoke_minter(&minter);
     client.update_score(&user, &100, &Some(minter));
+}
+
+#[test]
+fn test_legacy_mint_alias_still_issues_nft() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register(RemittanceNFT, ());
+    let client = RemittanceNFTClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let history_hash = create_test_hash(&env, 55);
+    client.mint(&user, &640, &history_hash, &None);
+
+    assert!(client.has_nft(&user));
+
+    let metadata = client.get_metadata(&user).unwrap();
+    assert_eq!(metadata.score, 640);
+    assert_eq!(metadata.history_hash, history_hash);
 }
 
 #[test]
@@ -282,6 +403,8 @@ fn test_backward_compatibility_migration() {
     env.as_contract(&contract_id, || {
         env.storage().persistent().set(&score_key, &750u32);
     });
+
+    assert!(client.has_nft(&user));
 
     // get_score should migrate and return the score
     assert_eq!(client.get_score(&user), 750);
@@ -401,7 +524,7 @@ fn test_lock_and_unlock_collateral() {
     client.authorize_minter(&locker);
 
     let history_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &history_hash, &None);
+    client.issue_nft(&user, &500, &history_hash, &None);
 
     // Initially, collateral should not be locked
     assert!(!client.is_collateral_locked(&user));
@@ -435,7 +558,7 @@ fn test_lock_collateral_already_locked() {
     client.authorize_minter(&locker);
 
     let history_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &history_hash, &None);
+    client.issue_nft(&user, &500, &history_hash, &None);
 
     // Lock collateral for loan ID 1
     client.lock_collateral(&user, &1, &locker);
@@ -481,7 +604,7 @@ fn test_unlock_unlocked_collateral() {
     client.authorize_minter(&locker);
 
     let history_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &history_hash, &None);
+    client.issue_nft(&user, &500, &history_hash, &None);
 
     // Try to unlock collateral that was never locked - should panic
     client.unlock_collateral(&user, &1, &locker);
@@ -504,7 +627,7 @@ fn test_unlock_collateral_wrong_loan_id() {
     client.authorize_minter(&locker);
 
     let history_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &history_hash, &None);
+    client.issue_nft(&user, &500, &history_hash, &None);
 
     // Lock collateral for loan ID 1
     client.lock_collateral(&user, &1, &locker);
@@ -529,7 +652,7 @@ fn test_lock_collateral_unauthorized_locker() {
     client.initialize(&admin);
 
     let history_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &history_hash, &None);
+    client.issue_nft(&user, &500, &history_hash, &None);
 
     // Try to lock collateral with unauthorized locker - should panic
     client.lock_collateral(&user, &1, &unauthorized_locker);
@@ -551,7 +674,7 @@ fn test_liquidate_collateral() {
     client.authorize_minter(&liquidator);
 
     let history_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &history_hash, &None);
+    client.issue_nft(&user, &500, &history_hash, &None);
 
     // Lock collateral for loan ID 1
     client.lock_collateral(&user, &1, &liquidator);
@@ -582,7 +705,7 @@ fn test_liquidate_unlocked_collateral() {
     client.authorize_minter(&liquidator);
 
     let history_hash = create_test_hash(&env, 1);
-    client.mint(&user, &500, &history_hash, &None);
+    client.issue_nft(&user, &500, &history_hash, &None);
 
     // Try to liquidate collateral that's not locked - should panic
     client.liquidate_collateral(&user, &1, &liquidator);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -28,7 +28,8 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
-    "**/*.mts"
-, "jest.config.js"  ],
+    "**/*.mts",
+    "jest.config.js"
+  ],
   "exclude": ["node_modules"]
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -250,11 +250,13 @@ console.log(process.env.NFT_CONTRACT_ID);
 **Key Methods:**
 - `initialize(admin)` - Initialize contract with admin
 - `authorize_minter(minter)` - Authorize address to mint NFTs
-- `mint_nft(owner, score)` - Mint new NFT with credit score
+- `issue_nft(user, initial_score, history_hash, issuer)` - Issue a remittance NFT with score and history proof
+- `mint(user, initial_score, history_hash, minter)` - Backward-compatible alias for existing integrations
+- `has_nft(user)` - Check whether an address already has an issued NFT
 - `get_score(owner)` - Get credit score for address
-- `update_score(owner, new_score)` - Update credit score
-- `lock_nft(nft_id)` - Lock NFT as collateral
-- `unlock_nft(nft_id)` - Unlock NFT after loan repayment
+- `update_score(owner, repayment_amount, minter)` - Update credit score from repayment activity
+- `lock_collateral(user, loan_id, locker)` - Lock NFT as collateral
+- `unlock_collateral(user, loan_id, locker)` - Unlock NFT after loan repayment
 
 ### Loan Manager Contract
 


### PR DESCRIPTION
## Summary
- add an explicit `issue_nft` flow to the remittance NFT contract, emit `NftIssued`, and keep `mint` as a backward-compatible alias
- expand remittance NFT unit coverage for issuance, authorization, migration, collateral, and event behavior
- fix the malformed `frontend/tsconfig.json` include array so the TypeScript config parses correctly

## Issue Coverage
- #6 Develop Remittance NFT Issuance Logic: implemented an explicit issuance entrypoint, emitted the `NftIssued` event, and preserved backward compatibility through `mint`
- #11 Write Unit Tests for Remittance NFT: added coverage for issuance permissions, metadata accuracy, migration behavior, collateral flows, and the issuance event

## Test plan
- [x] `cargo test -p remittance_nft`
- [x] `npm exec tsc -- --showConfig --project tsconfig.json`

Closes #6
Closes #11