### PR TITLE
fix: consolidate identity tables, add referential integrity, fix pgcrypto down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,68 @@ jobs:
       - name: Run tests
         run: cargo test
         working-directory: contracts
+
+  migration-test:
+    runs-on: ubuntu-latest
+    needs: [backend]
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: remitlend
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Migrate up
+        run: npm run migrate:up
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/remitlend
+
+      - name: Migrate down (all)
+        run: npm run migrate:down
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/remitlend
+
+      - name: Migrate up again (reversibility proof)
+        run: npm run migrate:up
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/remitlend
+
+      - name: Dump foreign-key constraints
+        run: |
+          psql "$DATABASE_URL" -c '\d+ scores'
+          psql "$DATABASE_URL" -c '\d+ loan_histories'
+          psql "$DATABASE_URL" -c '\d+ remittance_history'
+          psql "$DATABASE_URL" -c '\d+ user_profiles'
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/remitlend
+
+      - name: Verify referential integrity (insert with bad user_id must fail)
+        run: |
+          psql "$DATABASE_URL" -c "INSERT INTO scores (user_id, current_score) VALUES ('00000000-0000-0000-0000-000000000000', 500)" 2>&1 | grep -q 'violates foreign key' && echo "PASS: FK rejects invalid user_id" || (echo "FAIL: no FK on scores.user_id"; exit 1)
+          psql "$DATABASE_URL" -c "INSERT INTO loan_histories (user_id, borrower_wallet, amount, currency, interest_rate_bps, term_days, outstanding, status) VALUES ('00000000-0000-0000-0000-000000000000', 'GABC', 1000, 'USD', 500, 30, 1000, 'active')" 2>&1 | grep -q 'violates foreign key' && echo "PASS: FK rejects invalid user_id" || (echo "FAIL: no FK on loan_histories.user_id"; exit 1)
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/remitlend

--- a/backend/migrations/1771693000000_core-platform-schema.js
+++ b/backend/migrations/1771693000000_core-platform-schema.js
@@ -10,7 +10,8 @@ export const shorthands = undefined;
  * @returns {Promise<void> | void}
  */
 export const up = (pgm) => {
-    pgm.createExtension("pgcrypto", { ifNotExists: true });
+    // gen_random_uuid() is built into PostgreSQL 13+ — no pgcrypto extension needed.
+    // pgm.createExtension("pgcrypto", { ifNotExists: true });
 
     pgm.createTable("user_profiles", {
         id: {
@@ -124,5 +125,5 @@ export const down = (pgm) => {
     pgm.dropTable("contract_events");
     pgm.dropTable("loan_histories");
     pgm.dropTable("user_profiles");
-    pgm.dropExtension("pgcrypto", { ifExists: true });
+    // pgcrypto not created, so don't drop — gen_random_uuid() is built into PG13+.
 };

--- a/backend/migrations/1771694000000_schema-consolidation.js
+++ b/backend/migrations/1771694000000_schema-consolidation.js
@@ -21,8 +21,18 @@ export const shorthands = undefined;
  */
 export const up = (pgm) => {
     // ── 1. scores.user_id → uuid FK to user_profiles(id) ────────────────
-    // Drop unique constraint so we can change type
-    pgm.dropConstraint("scores", "scores_user_id_unique");
+    // Drop any unique constraint on user_id (PostgreSQL may name it
+    // scores_user_id_unique or scores_user_id_key depending on version).
+    pgm.sql(
+        `DO $$ DECLARE c text; BEGIN
+            SELECT con.conname INTO c FROM pg_constraint con
+            JOIN pg_class rel ON rel.oid = con.conrelid
+            WHERE rel.relname = 'scores' AND con.contype IN ('u','p')
+            AND con.conkey @> (SELECT array_agg(attnum) FROM pg_attribute
+                WHERE attrelid = rel.oid AND attname = 'user_id');
+            IF FOUND THEN EXECUTE 'ALTER TABLE scores DROP CONSTRAINT ' || c; END IF;
+        END $$`,
+    );
 
     // Convert varchar to uuid. Existing rows get NULL — a separate data
     // migration script is needed if there is existing production data.

--- a/backend/migrations/1771694000000_schema-consolidation.js
+++ b/backend/migrations/1771694000000_schema-consolidation.js
@@ -1,0 +1,113 @@
+/**
+ * Schema consolidation migration: canonical identity table, referential integrity,
+ * and safe migration reversibility.
+ *
+ * Design decision: `user_profiles` is the canonical identity table because:
+ *  - It holds wallet_address for on-chain linking
+ *  - It has KYC fields required by the platform
+ *  - `schema.types.ts` already mirrors it as `UserProfileRow`
+ *  - `loan_histories` already references it (though with an unsafe SET NULL)
+ *
+ * The redundant `users` table (email/password_hash only, no KYC/wallet) is dropped.
+ * Financial rows can no longer be orphaned: ON DELETE RESTRICT replaces SET NULL.
+ *
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+export const up = (pgm) => {
+    // ── 1. scores.user_id → uuid FK to user_profiles(id) ────────────────
+    // Drop unique constraint so we can change type
+    pgm.dropConstraint("scores", "scores_user_id_unique");
+
+    // Convert varchar to uuid. Existing rows get NULL — a separate data
+    // migration script is needed if there is existing production data.
+    pgm.sql(
+        `ALTER TABLE scores ALTER COLUMN user_id TYPE uuid USING NULL`,
+    );
+
+    pgm.addConstraint("scores", "scores_user_id_fkey", {
+        foreignKeys: {
+            columns: "user_id",
+            references: "user_profiles(id)",
+            onDelete: "RESTRICT",
+        },
+    });
+
+    // ── 2. remittance_history.user_id → uuid FK to user_profiles(id) ───
+    pgm.sql(
+        `ALTER TABLE remittance_history ALTER COLUMN user_id TYPE uuid USING NULL`,
+    );
+
+    pgm.addConstraint("remittance_history", "remittance_history_user_id_fkey", {
+        foreignKeys: {
+            columns: "user_id",
+            references: "user_profiles(id)",
+            onDelete: "RESTRICT",
+        },
+    });
+
+    // ── 3. loan_histories: replace SET NULL with RESTRICT ────────────────
+    // A loan must always have an owner; SET NULL silently orphans them.
+    pgm.dropConstraint("loan_histories", "loan_histories_user_id_fkey");
+
+    pgm.addConstraint("loan_histories", "loan_histories_user_id_fkey", {
+        foreignKeys: {
+            columns: "user_id",
+            references: "user_profiles(id)",
+            onDelete: "RESTRICT",
+        },
+    });
+
+    // ── 4. Drop redundant users table ──────────────────────────────────
+    pgm.dropTable("users", { ifExists: true });
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @returns {Promise<void> | void}
+ */
+export const down = (pgm) => {
+    // ── 1. Recreate users table ────────────────────────────────────────
+    pgm.createTable("users", {
+        id: "id",
+        email: { type: "varchar(255)", notNull: true, unique: true },
+        password_hash: { type: "varchar(255)", notNull: true },
+        created_at: {
+            type: "timestamp",
+            notNull: true,
+            default: pgm.func("current_timestamp"),
+        },
+    });
+    pgm.createIndex("users", "email");
+
+    // ── 2. loan_histories: revert to SET NULL ──────────────────────────
+    pgm.dropConstraint("loan_histories", "loan_histories_user_id_fkey");
+
+    pgm.addConstraint("loan_histories", "loan_histories_user_id_fkey", {
+        foreignKeys: {
+            columns: "user_id",
+            references: "user_profiles(id)",
+            onDelete: "SET NULL",
+        },
+    });
+
+    // ── 3. remittance_history: revert to varchar ───────────────────────
+    pgm.dropConstraint("remittance_history", "remittance_history_user_id_fkey");
+    pgm.sql(
+        `ALTER TABLE remittance_history ALTER COLUMN user_id TYPE varchar(255) USING NULL`,
+    );
+
+    // ── 4. scores: revert to varchar ──────────────────────────────────
+    pgm.dropConstraint("scores", "scores_user_id_fkey");
+    pgm.sql(
+        `ALTER TABLE scores ALTER COLUMN user_id TYPE varchar(255) USING NULL`,
+    );
+    pgm.addConstraint("scores", "scores_user_id_unique", {
+        unique: "user_id",
+    });
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -123,7 +123,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2248,7 +2247,6 @@
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2259,7 +2257,6 @@
       "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -2402,7 +2399,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2896,7 +2892,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3389,7 +3384,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4388,7 +4382,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4449,7 +4442,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4873,7 +4865,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6303,7 +6294,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7901,7 +7891,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -8150,7 +8139,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9382,7 +9370,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9514,7 +9501,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9751,7 +9737,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/db/schema.types.ts
+++ b/backend/src/db/schema.types.ts
@@ -1,6 +1,10 @@
 /**
  * TypeScript shapes mirroring PostgreSQL tables from node-pg-migrate.
- * Used by future repository/service layers; not wired to runtime yet.
+ *
+ * `user_profiles` is the canonical identity table after the schema
+ * consolidation migration (1771694000000). The redundant `users` table
+ * was dropped in favour of `user_profiles`, which holds wallet_address
+ * and KYC fields needed by the platform.
  */
 
 export type LoanStatus = "pending" | "active" | "repaid" | "defaulted";
@@ -18,6 +22,22 @@ export interface UserProfileRow {
   kyc_verified: boolean;
   created_at: Date;
   updated_at: Date;
+}
+
+export interface ScoreRow {
+  id: number;
+  user_id: string | null;
+  current_score: number;
+  updated_at: Date;
+}
+
+export interface RemittanceHistoryRow {
+  id: number;
+  user_id: string | null;
+  amount: string;
+  month: string;
+  status: string;
+  created_at: Date;
 }
 
 export interface LoanHistoryRow {


### PR DESCRIPTION
## Summary

Fixes #156 — resolves the two competing identity tables, missing referential integrity, and unsafe pgcrypto drop migration.

### Problems addressed

1. **Two competing identity tables** — `users` (serial id) and `user_profiles` (uuid id) both with unique email, no link between them
2. **Missing referential integrity** — `scores.user_id` (varchar) and `remittance_history.user_id` have no FKs
3. **Loan orphaning** — `loan_histories.user_id` uses `ON DELETE SET NULL`, silently orphaning loans
4. **Unsafe migration down** — `dropExtension("pgcrypto")` can break shared extensions
5. **Missing types** — `schema.types.ts` doesn't type `scores` or `remittance_history`

### Design decision

`user_profiles` is the canonical identity table because:
- It holds `wallet_address` for on-chain linking
- It has KYC fields required by the platform
- `schema.types.ts` already mirrors it as `UserProfileRow`
- `loan_histories` already references it

The redundant `users` table is dropped.

### Changes

| File | Change |
|---|---|
| `migrations/1771693000000_core-platform-schema.js` | Comment out pgcrypto createExtension/dropExtension (gen_random_uuid built into PG13+) |
| `migrations/1771694000000_schema-consolidation.js` | New migration: FKs + type changes + drop users table + complete down |
| `src/db/schema.types.ts` | Added `ScoreRow` and `RemittanceHistoryRow` types |
| `.github/workflows/ci.yml` | Added `migration-test` job: up → down → up + FK constraint verification |

### Acceptance criteria

- [x] Up → down → up succeeds on clean DB (CI job)
- [x] Single canonical identity table: `user_profiles`
- [x] `scores.user_id` and `loan_histories.user_id` have FK constraints — invalid inserts rejected
- [x] `loan_histories` uses `ON DELETE RESTRICT` — no orphaned loans
- [x] `pgcrypto` drop removed from down migration

Closes #156