### PR TITLE
fix(backend): stop leaking stack traces and raw DB errors to unauthenticated callers

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,8 @@
+# Controls error-response verbosity. Only "development" enables stack
+# traces in error response bodies; any other value (including unset)
+# is treated as production and keeps responses generic. Always set
+# this explicitly to "production" in real deployments.
+NODE_ENV=production
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 # For running backend inside docker-compose (default):
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/remitlend

--- a/backend/src/__tests__/errorHandler.unit.test.ts
+++ b/backend/src/__tests__/errorHandler.unit.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { Request, Response } from "express";
+import { errorHandler } from "../middleware/errorHandler.js";
+import { AppError } from "../errors/AppError.js";
+
+function createMockResponse() {
+  const res: Partial<Response> & { statusCode?: number; body?: unknown } = {};
+  res.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  }) as unknown as Response["status"];
+  res.json = jest.fn((payload: unknown) => {
+    res.body = payload;
+    return res as Response;
+  }) as unknown as Response["json"];
+  return res as Response & { statusCode?: number; body?: unknown };
+}
+
+describe("errorHandler - stack trace leak hygiene", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let consoleErrorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it("never includes a stack field when NODE_ENV is unset (fail-closed default)", () => {
+    delete process.env.NODE_ENV;
+
+    const res = createMockResponse();
+    const err = new Error("boom - internal file path /app/src/x.ts");
+    errorHandler(err, {} as Request, res, jest.fn() as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).not.toHaveProperty("stack");
+    expect(res.body).toEqual({
+      success: false,
+      message: "Internal server error",
+    });
+  });
+
+  it("never includes a stack field when NODE_ENV is set to something other than 'production'", () => {
+    process.env.NODE_ENV = "staging";
+
+    const res = createMockResponse();
+    const err = new Error("boom");
+    errorHandler(err, {} as Request, res, jest.fn() as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).not.toHaveProperty("stack");
+  });
+
+  it("never includes a stack field when NODE_ENV is explicitly 'production'", () => {
+    process.env.NODE_ENV = "production";
+
+    const res = createMockResponse();
+    const err = new Error("boom");
+    errorHandler(err, {} as Request, res, jest.fn() as never);
+
+    expect(res.body).not.toHaveProperty("stack");
+  });
+
+  it("logs the real error server-side even though it is withheld from the response", () => {
+    delete process.env.NODE_ENV;
+
+    const res = createMockResponse();
+    const err = new Error("boom");
+    errorHandler(err, {} as Request, res, jest.fn() as never);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it("still passes through operational AppError client-safe messages unchanged", () => {
+    delete process.env.NODE_ENV;
+
+    const res = createMockResponse();
+    const err = AppError.notFound("Resource not found");
+    errorHandler(err, {} as Request, res, jest.fn() as never);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      message: "Resource not found",
+    });
+    expect(res.body).not.toHaveProperty("stack");
+  });
+});

--- a/backend/src/__tests__/health.test.ts
+++ b/backend/src/__tests__/health.test.ts
@@ -65,5 +65,7 @@ describe('GET /health', () => {
 
     expect(response.body.status).toBe('error');
     expect(response.body.checks.database.status).toBe('error');
+    expect(response.body.checks.database.message).toBe('Database connection failed');
+    expect(JSON.stringify(response.body)).not.toMatch(/Connection refused/);
   });
 });

--- a/backend/src/__tests__/healthService.test.ts
+++ b/backend/src/__tests__/healthService.test.ts
@@ -52,17 +52,24 @@ describe('healthService', () => {
       expect(result).toEqual({ status: 'ok' });
     });
 
-    it('should return error when the database query fails', async () => {
+    it('should return a generic error message when the database query fails, without leaking the driver error', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
       const pool = {
         query: jest
           .fn<() => Promise<{ rows: unknown[] }>>()
-          .mockRejectedValue(new Error('Connection refused')),
+          .mockRejectedValue(new Error('Connection refused to postgres://user:pass@internal-host:5432/db')),
       } as unknown as pg.Pool;
 
       const result = await checkDatabase(pool);
 
       expect(result.status).toBe('error');
-      expect(result.message).toBe('Connection refused');
+      expect(result.message).toBe('Database connection failed');
+      expect(result.message).not.toMatch(/postgres:\/\//);
+      expect(result.message).not.toMatch(/internal-host/);
+      // The real error is still logged server-side.
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -40,9 +40,13 @@ export const errorHandler = (
   }
 
   // ── Unexpected / Programming Errors ──────────────────────────
+  // Verbose internals (stack traces) must never leave the server by
+  // default. They are only included in the response body when
+  // explicitly opted into via NODE_ENV=development - unset or any
+  // other value (including a typo'd "production") stays fail-closed.
   console.error("Unhandled error:", err);
 
-  const isDevelopment = process.env.NODE_ENV !== "production";
+  const isDevelopment = process.env.NODE_ENV === "development";
 
   res.status(500).json({
     success: false,

--- a/backend/src/services/healthService.ts
+++ b/backend/src/services/healthService.ts
@@ -35,10 +35,13 @@ export async function checkDatabase(
     await pool.query('SELECT 1');
     return { status: 'ok' };
   } catch (error) {
+    // Log the real driver error server-side only. The raw message can
+    // contain connection-string fragments, hostnames, or other driver
+    // internals and must never reach the unauthenticated /health caller.
+    console.error('Database health check failed:', error);
     return {
       status: 'error',
-      message:
-        error instanceof Error ? error.message : 'Database connection failed',
+      message: 'Database connection failed',
     };
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     command: npm run dev
     ports:
       - "3001:3001"
+    environment:
+      NODE_ENV: production
     env_file:
       - ./backend/.env
     volumes:


### PR DESCRIPTION
## Problem

Two paths returned internal implementation detail to unauthenticated callers:

1. `errorHandler.ts` computed `isDevelopment = process.env.NODE_ENV !== "production"` and included `err.stack` in the JSON response body whenever that was true. Since `NODE_ENV` was never declared/set anywhere in this repo, the default posture was fail-open: any deployment that forgot to explicitly set `NODE_ENV=production` leaked full stack traces on every unhandled 500.
2. `healthService.checkDatabase` returned the raw pg driver `error.message` into `checks.database.message`, served unauthenticated at `/health`. This can leak connection-string fragments, hostnames, and driver-internal error text regardless of `NODE_ENV`.

## Fix

1. **`errorHandler.ts`**: inverted the default. Verbose output is now opt-in, not opt-out — `err.stack` is only included in the response body when `NODE_ENV === "development"` explicitly. Any other value, including unset (the default), keeps the response generic. The real error is still logged server-side via the existing `console.error("Unhandled error:", err)` call. `AppError` operational messages (client-safe by design) continue to pass through unchanged.
2. **`healthService.ts`**: `checkDatabase` now logs the real driver error via `console.error` and returns a fixed generic message (`"Database connection failed"`) instead of the raw `error.message`, for both the unauthenticated `/health` response and any caller of the service.
3. **`NODE_ENV` declaration**: added to `backend/.env.example` (documented as `production` with an explanatory comment) and to the `backend` service in `docker-compose.yml`, so the intended production posture is explicit — while the code itself is now safe even if `NODE_ENV` is completely unset.
4. **Tests**: added `backend/src/__tests__/errorHandler.unit.test.ts` unit-testing the handler directly against a mock `Response`, covering NODE_ENV unset / "staging" / "production" all producing no `stack` field, the real error still being logged, and `AppError` messages passing through unchanged. Updated `healthService.test.ts` and `health.test.ts` to assert the driver error text is no longer present in `checkDatabase`'s result or the `/health` response body.

## Sample response bodies (as requested by the issue's acceptance criteria)

**500 response, `NODE_ENV` unset:**
```json
{
  "success": false,
  "message": "Internal server error"
}
```

**500 response, `NODE_ENV=production`:**
```json
{
  "success": false,
  "message": "Internal server error"
}
```
(In both cases the real error, e.g. `"secret internal detail /app/src/db.ts:42"`, is only visible in the server-side `console.error` log, never in the response body.)

**`/health` with simulated DB failure, `NODE_ENV` unset:**
```json
{
  "status": "error",
  "uptime": 0.244,
  "timestamp": 1785381949863,
  "checks": {
    "database": { "status": "error", "message": "Database connection failed" },
    "horizon": { "status": "ok" }
  }
}
```

**`/health` with simulated DB failure, `NODE_ENV=production`:**
```json
{
  "status": "error",
  "uptime": 0.245,
  "timestamp": 1785381949864,
  "checks": {
    "database": { "status": "error", "message": "Database connection failed" },
    "horizon": { "status": "ok" }
  }
}
```
(The simulated driver error was `password authentication failed for user "postgres" at host db.internal.example.com:5432` — none of that text appears in either response.)

## Test plan

- [x] `npm run build` (tsc) passes
- [x] `npm run lint` passes with no warnings
- [x] `npm test` — all 10 suites / 80 tests pass, including the new/updated tests:
  - unhandled error response has no `stack` field with `NODE_ENV` unset
  - unhandled error response has no `stack` field with `NODE_ENV` set to a non-`"production"` value (`"staging"`)
  - unhandled error response has no `stack` field with `NODE_ENV=production`
  - the real error is still logged server-side via `console.error`
  - `AppError` operational messages still reach the client unchanged
  - `checkDatabase` returns a generic message with no driver-specific text, while still logging the real error
  - `GET /health` with a simulated DB failure returns a generic database message with no driver text

## Out of scope (per issue's own framing)

The issue text describes a large multi-phase epic, but the actual required technical fix is the scoped backend change above. Per the issue, frontend files (`apiClient.ts`, `useApi.ts`) were reviewed and require no changes — they already just read `.message` from the response body with no logic that assumes a `stack` field is present. CI-workflow assertions (issue's "Phase 4") were left out as a nice-to-have, not required for correctness.

Fixes #157